### PR TITLE
Re-fix Python layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,35 @@
+RBDyn
+=====
+
 [![Build Status](https://travis-ci.org/jorisv/RBDyn.svg?branch=master)](https://travis-ci.org/jorisv/RBDyn)
 
-RBDyn provide a set of class and function to model the dynamics of rigid body system.
+RBDyn provide a set of class and function to model the dynamics of rigid body systems.
 
-This implementation is based on Roy Featherstone Rigid Body Dynamics Algorithms book.
+This implementation is based on Roy Featherstone's "Rigid Body Dynamics Algorithms" book.
+
+## Dependencies
+
+* C++ compiler with C++11 support
+* Eigen 3
+* CMake
+* Boost
+* SpaceVecAlg
+
+For Python bindings:
+
+* Python 2 or 3
+* PyBindGen
+
+## Install
+
+```sh
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=[your install prefix]
+make
+make install
+```
+
+Note: the usual install prefix is `/usr`, but it defaults to `/usr/local`.
+
+If you generate Python bindings on Debian-based distributions (e.g. Ubuntu), you may want to choose the Debian layout for Python packages (e.g. `/usr/lib/python2.7/dist-packages/`) instead of the default one (e.g. `/usr/lib/python2.7/site-packages/`). If this is the case, add the `-DPYTHON_DEB_LAYOUT=ON` flag to the CMake command.
+

--- a/binding/python/CMakeLists.txt
+++ b/binding/python/CMakeLists.txt
@@ -4,40 +4,30 @@ INCLUDE(../../cmake/python.cmake)
 SET(Python_ADDITIONAL_VERSIONS 2.7)
 FINDPYTHON()
 
-## Define PYTHON_DISTLIB
-EXECUTE_PROCESS(
-  COMMAND "${PYTHON_EXECUTABLE}" "-c"
-  "import sys, os; print os.sep.join(['lib', 'python' + sys.version[:3], 'dist-packages'])"
-  OUTPUT_VARIABLE PYTHON_DISTLIB
-  ERROR_QUIET)
-# Remove final \n of the variable PYTHON_DISTLIB
-STRING(REPLACE "\n" "" PYTHON_DISTLIB "${PYTHON_DISTLIB}")
+# Create the package in build dir for testing purpose
+SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/rbdyn)
+CONFIGURE_FILE(__init__.py ${CMAKE_CURRENT_BINARY_DIR}/rbdyn/__init__.py COPYONLY)
+SET(OUTPUT_BINDING ${CMAKE_CURRENT_BINARY_DIR}/rbdyn.cpp)
 
-# create the package in build dir for testing purpose
-set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/rbdyn)
-configure_file(__init__.py ${CMAKE_CURRENT_BINARY_DIR}/rbdyn/__init__.py COPYONLY)
-
-set(OUTPUT_BINDING ${CMAKE_CURRENT_BINARY_DIR}/rbdyn.cpp)
-
-# generate python binding code
-add_custom_command (
+# Generate Python binding code
+ADD_CUSTOM_COMMAND (
   OUTPUT ${OUTPUT_BINDING}
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate.py ${OUTPUT_BINDING}
   DEPENDS generate.py
 )
 
-# build the library
-set(SOURCES ${OUTPUT_BINDING})
-include_directories(.)
-include_directories(../../src)
-include_directories(${PYTHON_INCLUDE_DIRS})
+# Build the library
+SET(SOURCES ${OUTPUT_BINDING})
 
-add_library(_rbdyn SHARED ${SOURCES})
+INCLUDE_DIRECTORIES(SYSTEM ${PYTHON_INCLUDE_PATH})
+INCLUDE_DIRECTORIES(.)
+INCLUDE_DIRECTORIES(../../src)
+
+ADD_LIBRARY(_rbdyn SHARED ${SOURCES})
 PKG_CONFIG_USE_DEPENDENCY(_rbdyn SpaceVecAlg)
-target_link_libraries(_rbdyn RBDyn)
-set_target_properties(_rbdyn PROPERTIES PREFIX "")
+TARGET_LINK_LIBRARIES(_rbdyn RBDyn)
+SET_TARGET_PROPERTIES(_rbdyn PROPERTIES PREFIX "")
 
-# install rules
-set(INSTALL_PATH "${PYTHON_DISTLIB}/rbdyn/")
-install(TARGETS _rbdyn DESTINATION ${INSTALL_PATH})
-install(FILES __init__.py DESTINATION ${INSTALL_PATH})
+# Install rules
+INSTALL(TARGETS _rbdyn DESTINATION "${PYTHON_SITELIB}/rbdyn")
+PYTHON_INSTALL_BUILD(rbdyn __init__.py "${PYTHON_SITELIB}")


### PR DESCRIPTION
This allows RBDyn to conform with the usual Python layout on Linux, i.e. the whole `site-packages` vs `dist-packages` conflict. This also fixes things for systems with multiple Python versions (**_cough**_ Arch **_cough**_ and probably the next Ubuntu release). FYI, this is also how things are done in ROS.

We should probably explain how to install RBDyn in the README to have a smooth transition.

TL;DR: went "Bussy" on Python bindings, wait for README update.

cc @haudren @jovenagravante
