### PR TITLE
tests: use Boost.Test's shared library

### DIFF
--- a/tests/AlgoTest.cpp
+++ b/tests/AlgoTest.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE Algo
 #include <boost/test/unit_test.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/tests/BodyTest.cpp
+++ b/tests/BodyTest.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE BodyTest
 #include <boost/test/unit_test.hpp>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 ENABLE_TESTING()
 
-set(Boost_USE_STATIC_LIBS ON)
 set(BOOST_COMPONENTS unit_test_framework timer system)
 SEARCH_FOR_BOOST()
+add_definitions(-DBOOST_TEST_DYN_LINK)
 
 include_directories("${PROJECT_SOURCE_DIR}/src")
 include_directories(${Boost_INCLUDE_DIRS})

--- a/tests/CoMTest.cpp
+++ b/tests/CoMTest.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE CoMTest
 #include <boost/test/unit_test.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/tests/DynamicsBench.cpp
+++ b/tests/DynamicsBench.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE DynamicsBench
 #include <boost/test/unit_test.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/tests/DynamicsTest.cpp
+++ b/tests/DynamicsTest.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE Dynamics
 #include <boost/test/unit_test.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/tests/IDIMTest.cpp
+++ b/tests/IDIMTest.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE IDIMTest
 #include <boost/test/unit_test.hpp>
 

--- a/tests/JacobianBench.cpp
+++ b/tests/JacobianBench.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE JacobianBench
 #include <boost/test/unit_test.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/tests/JacobianTest.cpp
+++ b/tests/JacobianTest.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE Jacobian
 #include <boost/test/unit_test.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/tests/JointTest.cpp
+++ b/tests/JointTest.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE JointTest
 #include <boost/test/unit_test.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/tests/MomentumTest.cpp
+++ b/tests/MomentumTest.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE MomentumTest
 #include <boost/test/unit_test.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/tests/MultiBodyTest.cpp
+++ b/tests/MultiBodyTest.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 // boost
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE MultiBodyTest
 #include <boost/test/unit_test.hpp>
 #include <boost/math/constants/constants.hpp>


### PR DESCRIPTION
This disables `Boost_USE_STATIC_LIBS` and sets `BOOST_TEST_DYN_LINK` with CMake instead.
