### PR TITLE
Add Inverse Kinematics

### DIFF
--- a/binding/python/generate.py
+++ b/binding/python/generate.py
@@ -507,7 +507,6 @@ def build_id(id):
 
 
 def build_ik(ik):
-  ik.add_constructor([])
   ik.add_copy_constructor()
   ik.add_constructor([param('const rbd::MultiBody&', 'mb'), param('int', 'ef_index')])
 

--- a/binding/python/generate.py
+++ b/binding/python/generate.py
@@ -506,6 +506,16 @@ def build_id(id):
   id.add_method('f', retval('std::vector<sva::ForceVecd>'), [], is_const=True)
 
 
+def build_ik(ik):
+  ik.add_constructor([])
+  ik.add_copy_constructor()
+  ik.add_constructor([param('const rbd::MultiBody&', 'mb'), param('int', 'ef_index')])
+
+  ik.add_method('sInverseKinematics', retval('bool'),
+                 [param('const rbd::MultiBody&', 'mb'),
+                  param('rbd::MultiBodyConfig&', 'mbc'),
+                  param('const sva::PTransformd&', 'ef_target')],
+                 throw=[dom_ex], custom_name='inverseKinematics')
 
 def build_fd(id):
   fd.add_constructor([])
@@ -763,6 +773,7 @@ if __name__ == '__main__':
   rbd.add_include('<Jacobian.h>')
   rbd.add_include('<ID.h>')
   rbd.add_include('<FD.h>')
+  rbd.add_include('<IK.h>')
   rbd.add_include('<EulerIntegration.h>')
   rbd.add_include('<CoM.h>')
   rbd.add_include('<Momentum.h>')
@@ -788,6 +799,7 @@ if __name__ == '__main__':
   jac = rbd.add_class('Jacobian')
   id = rbd.add_class('InverseDynamics')
   fd = rbd.add_class('ForwardDynamics')
+  ik = rbd.add_class('InverseKinematics')
   comDummy = rbd.add_class('CoMJacobianDummy')
   comJac = rbd.add_class('CoMJacobian')
   momentumMat = rbd.add_class('CentroidalMomentumMatrix')
@@ -828,6 +840,7 @@ if __name__ == '__main__':
   build_algo(rbd)
   build_id(id)
   build_fd(fd)
+  build_ik(ik)
   build_com(rbd, comDummy, comJac)
   build_momentum(rbd, momentumMat)
   build_zmp(rbd)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(SOURCES MultiBodyGraph.cpp MultiBody.cpp MultiBodyConfig.cpp
-  FK.cpp FV.cpp FA.cpp Jacobian.cpp ID.cpp FD.cpp EulerIntegration.cpp CoM.cpp
+	FK.cpp FV.cpp FA.cpp Jacobian.cpp ID.cpp FD.cpp IK.cpp EulerIntegration.cpp CoM.cpp
   Momentum.cpp ZMP.cpp IDIM.cpp VisServo.cpp)
 set(HEADERS Body.h Joint.h MultiBodyGraph.h MultiBody.h MultiBodyConfig.h
-  FK.h FV.h FA.h Jacobian.h ID.h FD.h EulerIntegration.h CoM.h
+	FK.h FV.h FA.h Jacobian.h ID.h FD.h IK.h EulerIntegration.h CoM.h
   Momentum.h ZMP.h IDIM.h VisServo.h)
 
 add_library(RBDyn SHARED ${SOURCES} ${HEADERS})

--- a/src/IK.cpp
+++ b/src/IK.cpp
@@ -1,0 +1,92 @@
+// This file is part of RBDyn.
+//
+// RBDyn is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// RBDyn is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with RBDyn.  If not, see <http://www.gnu.org/licenses/>.
+
+// associated header
+#include "IK.h"
+
+// includes
+// RBDyn
+#include "FK.h"
+#include "FV.h"
+#include "MultiBody.h"
+#include "MultiBodyConfig.h"
+
+//SpaceVecAlg
+#include <SpaceVecAlg/SpaceVecAlg>
+
+namespace rbd
+{
+
+static const int MAX_IK_ITERATIONS = 50;
+static const double LAMBDA = 0.9;
+static const double IK_THRESHOLD = 1e-8;
+static const double ALMOST_ZERO = 1e-8;
+
+InverseKinematics::InverseKinematics(const MultiBody& mb, int ef_index):
+	ef_index_(ef_index),
+	jac_(mb, mb.body(ef_index).id()),
+	svd_()
+{
+}
+
+struct CwiseRoundOp {
+	CwiseRoundOp(const double& inf, const double& sup) : m_inf(inf), m_sup(sup) {}
+	double operator()(const double& x) const { return x>m_inf && x<m_sup ? 0 : x; }
+	double m_inf, m_sup;
+};
+
+bool InverseKinematics::inverseKinematics(const MultiBody& mb, MultiBodyConfig& mbc,
+                                          const sva::PTransformd& ef_target)
+{
+	int iter = 0;
+	bool converged = false;
+	int dof = 0;
+	rbd::forwardKinematics(mb, mbc);
+	Eigen::MatrixXd jacMat;
+	Eigen::Vector6d v = Eigen::Vector6d::Ones();
+	Eigen::Vector3d rotErr;
+	Eigen::VectorXd res = Eigen::VectorXd::Zero(3);
+	while(iter < MAX_IK_ITERATIONS && ! converged)
+	{
+		jacMat = jac_.jacobian(mb, mbc);
+		//non-strict zeros in jacobian can be a problem...
+		double eps = ALMOST_ZERO;
+		jacMat = jacMat.unaryExpr(CwiseRoundOp(-eps, eps));
+		svd_.compute(jacMat, Eigen::ComputeThinU | Eigen::ComputeThinV);
+		rotErr = sva::rotationError(mbc.bodyPosW[ef_index_].rotation(),
+		                            ef_target.rotation());
+		v << rotErr, ef_target.translation() - mbc.bodyPosW[ef_index_].translation();
+		converged = v.norm() < IK_THRESHOLD;
+		res = svd_.solve(v);
+
+		dof = 0;
+		for(auto index : jac_.jointsPath())
+		{
+			std::vector<double>& qi = mbc.q[index];
+			for(auto qv=qi.begin(); qv!=qi.end(); ++qv)
+			{
+				*qv += LAMBDA*res[dof];
+				++dof;
+			}
+		}
+
+		rbd::forwardKinematics(mb, mbc);
+		rbd::forwardVelocity(mb, mbc);
+		iter++;
+	}
+	return converged;
+}
+
+} // namespace rbd

--- a/src/IK.cpp
+++ b/src/IK.cpp
@@ -29,6 +29,16 @@
 namespace rbd
 {
 
+namespace {
+
+struct CwiseRoundOp {
+	CwiseRoundOp(const double& inf, const double& sup) : m_inf(inf), m_sup(sup) {}
+	double operator()(const double& x) const { return x>m_inf && x<m_sup ? 0 : x; }
+	double m_inf, m_sup;
+};
+
+} // anonymous
+
 InverseKinematics::InverseKinematics(const MultiBody& mb, int ef_index):
 	max_iterations_(ik::MAX_ITERATIONS),
 	lambda_(ik::LAMBDA),
@@ -39,12 +49,6 @@ InverseKinematics::InverseKinematics(const MultiBody& mb, int ef_index):
 	svd_()
 {
 }
-
-struct CwiseRoundOp {
-	CwiseRoundOp(const double& inf, const double& sup) : m_inf(inf), m_sup(sup) {}
-	double operator()(const double& x) const { return x>m_inf && x<m_sup ? 0 : x; }
-	double m_inf, m_sup;
-};
 
 bool InverseKinematics::inverseKinematics(const MultiBody& mb, MultiBodyConfig& mbc,
                                           const sva::PTransformd& ef_target)

--- a/src/IK.cpp
+++ b/src/IK.cpp
@@ -58,7 +58,7 @@ bool InverseKinematics::inverseKinematics(const MultiBody& mb, MultiBodyConfig& 
 	Eigen::Vector6d v = Eigen::Vector6d::Ones();
 	Eigen::Vector3d rotErr;
 	Eigen::VectorXd res = Eigen::VectorXd::Zero(3);
-	while(iter < MAX_IK_ITERATIONS && ! converged)
+	while( ! converged && iter < MAX_IK_ITERATIONS)
 	{
 		jacMat = jac_.jacobian(mb, mbc);
 		//non-strict zeros in jacobian can be a problem...

--- a/src/IK.cpp
+++ b/src/IK.cpp
@@ -75,9 +75,9 @@ bool InverseKinematics::inverseKinematics(const MultiBody& mb, MultiBodyConfig& 
 		for(auto index : jac_.jointsPath())
 		{
 			std::vector<double>& qi = mbc.q[index];
-			for(auto qv=qi.begin(); qv!=qi.end(); ++qv)
+			for(auto &qv : qi)
 			{
-				*qv += LAMBDA*res[dof];
+				qv += LAMBDA*res[dof];
 				++dof;
 			}
 		}

--- a/src/IK.cpp
+++ b/src/IK.cpp
@@ -89,4 +89,15 @@ bool InverseKinematics::inverseKinematics(const MultiBody& mb, MultiBodyConfig& 
 	return converged;
 }
 
+bool InverseKinematics::sInverseKinematics(const MultiBody& mb, MultiBodyConfig& mbc,
+					   const sva::PTransformd& ef_target)
+{
+	checkMatchQ(mb, mbc);
+	checkMatchBodyPos(mb, mbc);
+	checkMatchJointConf(mb, mbc);
+	checkMatchParentToSon(mb, mbc);
+
+	return inverseKinematics(mb, mbc, ef_target);
+}
+
 } // namespace rbd

--- a/src/IK.cpp
+++ b/src/IK.cpp
@@ -1,5 +1,7 @@
 // This file is part of RBDyn.
 //
+// Copyright (C) 2012 - 2016 CNRS-AIST JRL, CNRS-UM LIRMM
+//
 // RBDyn is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/src/IK.h
+++ b/src/IK.h
@@ -44,8 +44,6 @@ static constexpr double ALMOST_ZERO = 1e-8;
 class InverseKinematics
 {
 public:
-	InverseKinematics()
-	{}
 	/// @param mb MultiBody associated with this algorithm.
 	InverseKinematics(const MultiBody& mb, int ef_index);
 	/**

--- a/src/IK.h
+++ b/src/IK.h
@@ -51,8 +51,10 @@ public:
 	* @param mb MultiBody used has model.
 	* @param mbc Use q generalized position vector
 	* @return bool if computation has converged
-	* Fill q with new generalized position, bodyPosW, jointConfig
-	* and parentToSon
+	* Fill q with new generalized position, update bodyPosW,
+	* jointConfig and parentToSon. All computations are done
+	* in-place : even if computation does not converge,
+	* mbc will be modified.
 	*/
 	bool inverseKinematics(const MultiBody& mb, MultiBodyConfig& mbc,
 			       const sva::PTransformd& ef_target);

--- a/src/IK.h
+++ b/src/IK.h
@@ -47,12 +47,13 @@ public:
 	* Fill q with new generalized position
 	*/
 	bool inverseKinematics(const MultiBody& mb, MultiBodyConfig& mbc,
-                               const sva::PTransformd& ef_target);
+			       const sva::PTransformd& ef_target);
 
 	/** safe version of @see inverseKinematics.
 	* @throw std::domain_error If mb doesn't match mbc.
 	*/
-	//void sInverseKinematics(const MultiBody& mb, MultiBodyConfig& mbc);
+	bool sInverseKinematics(const MultiBody& mb, MultiBodyConfig& mbc,
+				const sva::PTransformd& ef_target);
 	/**
 	* @brief Find q that minimizes the distance between ef and ef_target.
 	* @return Bool if convergence has been reached

--- a/src/IK.h
+++ b/src/IK.h
@@ -1,5 +1,7 @@
 // This file is part of RBDyn.
 //
+// Copyright (C) 2012-2016 CNRS-AIST JRL, CNRS-UM LIRMM
+//
 // RBDyn is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/src/IK.h
+++ b/src/IK.h
@@ -29,6 +29,15 @@ namespace rbd
 class MultiBody;
 class MultiBodyConfig;
 
+namespace ik {
+
+static constexpr int MAX_ITERATIONS = 50;
+static constexpr double LAMBDA = 0.9;
+static constexpr double THRESHOLD = 1e-8;
+static constexpr double ALMOST_ZERO = 1e-8;
+
+} // ik
+
 /**
 	* Inverse Kinematics algorithm.
 	*/
@@ -58,6 +67,12 @@ public:
 	* @brief Find q that minimizes the distance between ef and ef_target.
 	* @return Bool if convergence has been reached
 	*/
+
+public:
+	int max_iterations_;
+	double lambda_;
+	double threshold_;
+	double almost_zero_;
 
 private:
 	// @brief ef_index is the End Effector index used to build jacobian

--- a/src/IK.h
+++ b/src/IK.h
@@ -43,7 +43,7 @@ static constexpr double ALMOST_ZERO = 1e-8;
 /**
 	* Inverse Kinematics algorithm.
 	*/
-class InverseKinematics
+class RBDYN_DLLAPI InverseKinematics
 {
 public:
 	/// @param mb MultiBody associated with this algorithm.

--- a/src/IK.h
+++ b/src/IK.h
@@ -53,7 +53,8 @@ public:
 	* @param mb MultiBody used has model.
 	* @param mbc Use q generalized position vector
 	* @return bool if computation has converged
-	* Fill q with new generalized position
+	* Fill q with new generalized position, bodyPosW, jointConfig
+	* and parentToSon
 	*/
 	bool inverseKinematics(const MultiBody& mb, MultiBodyConfig& mbc,
 			       const sva::PTransformd& ef_target);
@@ -68,10 +69,13 @@ public:
 	* @return Bool if convergence has been reached
 	*/
 
-public:
+	// @brief Maximum number of iterations
 	int max_iterations_;
+	// @brief Learning rate
 	double lambda_;
+	// @brief Stopping criterion
 	double threshold_;
+	// @brief Rounding threshold for the Jacobian
 	double almost_zero_;
 
 private:

--- a/src/IK.h
+++ b/src/IK.h
@@ -1,0 +1,68 @@
+// This file is part of RBDyn.
+//
+// RBDyn is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// RBDyn is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with RBDyn.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+// includes
+// std
+#include <vector>
+
+// SpaceVecAlg
+#include <SpaceVecAlg/SpaceVecAlg>
+
+#include "Jacobian.h"
+
+namespace rbd
+{
+class MultiBody;
+class MultiBodyConfig;
+
+/**
+	* Inverse Kinematics algorithm.
+	*/
+class InverseKinematics
+{
+public:
+	InverseKinematics()
+	{}
+	/// @param mb MultiBody associated with this algorithm.
+	InverseKinematics(const MultiBody& mb, int ef_index);
+	/**
+	* Compute the inverse kinematics.
+	* @param mb MultiBody used has model.
+	* @param mbc Use q generalized position vector
+	* @return bool if computation has converged
+	* Fill q with new generalized position
+	*/
+	bool inverseKinematics(const MultiBody& mb, MultiBodyConfig& mbc,
+                               const sva::PTransformd& ef_target);
+
+	/** safe version of @see inverseKinematics.
+	* @throw std::domain_error If mb doesn't match mbc.
+	*/
+	//void sInverseKinematics(const MultiBody& mb, MultiBodyConfig& mbc);
+	/**
+	* @brief Find q that minimizes the distance between ef and ef_target.
+	* @return Bool if convergence has been reached
+	*/
+
+private:
+	// @brief ef_index is the End Effector index used to build jacobian
+	int ef_index_;
+	Jacobian jac_;
+	Eigen::JacobiSVD<Eigen::MatrixXd> svd_;
+};
+
+} // namespace rbd

--- a/tests/AlgoTest.cpp
+++ b/tests/AlgoTest.cpp
@@ -702,7 +702,40 @@ BOOST_AUTO_TEST_CASE(IKTest)
   rbd::forwardKinematics(mb, mbc);
   BOOST_CHECK(ik.inverseKinematics(mb, mbc, target));
   pos_vec = Eigen::Vector3d(mbc.q[1][0], mbc.q[2][0], mbc.q[3][0]);
-  std::cout << pos_vec.transpose() << std::endl;
-  std::cout << solution.transpose() << std::endl;
   BOOST_CHECK_SMALL((pos_vec - solution).norm(), TOL);
+}
+
+BOOST_AUTO_TEST_CASE(FailureIKTest)
+{
+  using namespace Eigen;
+  rbd::MultiBody mb;
+  rbd::MultiBodyConfig mbc;
+  rbd::MultiBodyGraph mbg;
+
+  std::tie(mb, mbc, mbg) = makeXYZarm();
+
+  rbd::InverseKinematics ik(mb, 3);
+
+  rbd::forwardKinematics(mb, mbc);
+  rbd::forwardVelocity(mb, mbc);
+
+  // This target is outside the reach of the arm
+  sva::PTransformd target(sva::RotX(M_PI/2), Eigen::Vector3d(0., 0.5, 2.5));
+  BOOST_CHECK(!ik.inverseKinematics(mb, mbc, target));
+
+  Eigen::VectorXd q_target(mb.nrParams());
+  Eigen::VectorXd q(mb.nrParams());
+
+  q_target << M_PI/2, 0, 0;
+  rbd::paramToVector(mbc.q, q);
+
+  BOOST_CHECK_SMALL((q_target - q).norm(), TOL);
+
+  /* This target is reachable, but IK will fail if given
+   * a too low maximum number of iterations */
+  ik.max_iterations_ = 10;
+  sva::PTransformd reachable_target(sva::RotX(-M_PI/2), Eigen::Vector3d(0., 0.5, -2.));
+  BOOST_CHECK(!ik.inverseKinematics(mb, mbc, reachable_target));
+  ik.max_iterations_ = 40;
+  BOOST_CHECK(ik.inverseKinematics(mb, mbc, reachable_target));
 }


### PR DESCRIPTION
This pull request adds an implementation of Inverse Kinematics. It follows precisely the implementation that was done in [OpenHRP3](https://github.com/fkanehiro/openhrp3/blob/eaf23dc15cdc631e68d38a7db13ec6c9c9c73141/hrplib/hrpModel/InverseKinematics.h).

I am not very happy with the fact that we have to add constants in the .cpp file, but I think that algorithms should work without any tuning: if this is a problem, I can always add accessors to modify them.

Do not hesitate to tell me if the tests and/or doc seems incomplete.

Cheers,
Hervé
