### PR TITLE
Store mimic joint information

### DIFF
--- a/src/Joint.h
+++ b/src/Joint.h
@@ -107,7 +107,7 @@ public:
 	 * @param multiplier Mimic multiplier
 	 * @param offset Mimic offset
 	 */
-	void set_mimic(const std::string & name, double multiplier, double offset);
+	void setMimic(const std::string & name, double multiplier, double offset);
 
 	/// @return Joint type.
 	Type type() const
@@ -159,27 +159,27 @@ public:
 	}
 
 	/// @return True if the joint is a mimic joint
-	bool is_mimic() const
+	bool isMimic() const
 	{
-		return is_mimic_;
+		return isMimic_;
 	}
 
 	/// @return Mimiced name
-	const std::string& mimic_name() const
+	const std::string& mimicName() const
 	{
-		return mimic_name_;
+		return mimicName_;
 	}
 
 	/// @return Mimic multiplier
-	double mimic_multiplier() const
+	double mimicMultiplier() const
 	{
-		return mimic_multiplier_;
+		return mimicMultiplier_;
 	}
 
 	/// @return Mimic offset
-	double mimic_offset() const
+	double mimicOffset() const
 	{
-		return mimic_offset_;
+		return mimicOffset_;
 	}
 
 	/// @return Joint motion subspace in successor frame coordinate.
@@ -278,10 +278,10 @@ private:
 
 	std::string name_;
 
-	bool is_mimic_ = false;
-	std::string mimic_name_ = "";
-	double mimic_multiplier_ = 1.0;
-	double mimic_offset_ = 0.0;
+	bool isMimic_ = false;
+	std::string mimicName_ = "";
+	double mimicMultiplier_ = 1.0;
+	double mimicOffset_ = 0.0;
 };
 
 
@@ -348,12 +348,12 @@ inline Joint::Joint(Type type,	bool forward, std::string name):
 	constructJoint(type, Eigen::Vector3d::UnitZ());
 }
 
-inline void Joint::set_mimic(const std::string & name, double multiplier, double offset)
+inline void Joint::setMimic(const std::string & name, double multiplier, double offset)
 {
-	is_mimic_ = true;
-	mimic_name_ = name;
-	mimic_multiplier_ = multiplier;
-	mimic_offset_ = offset;
+	isMimic_ = true;
+	mimicName_ = name;
+	mimicMultiplier_ = multiplier;
+	mimicOffset_ = offset;
 }
 
 
@@ -463,11 +463,11 @@ inline sva::MotionVecd Joint::tanAccel(const std::vector<double>& alphaD) const
 inline std::vector<double> Joint::zeroParam() const
 {
 	auto q = ZeroParam(type_);
-	if(is_mimic_)
+	if(isMimic_)
 	{
 		for(auto & qi : q)
 		{
-			qi += mimic_offset_;
+			qi += mimicOffset_;
 		}
 	}
 	return q;

--- a/src/Joint.h
+++ b/src/Joint.h
@@ -107,7 +107,7 @@ public:
 	 * @param multiplier Mimic multiplier
 	 * @param offset Mimic offset
 	 */
-	void setMimic(const std::string & name, double multiplier, double offset);
+	void makeMimic(const std::string & name, double multiplier, double offset);
 
 	/// @return Joint type.
 	Type type() const
@@ -348,7 +348,7 @@ inline Joint::Joint(Type type,	bool forward, std::string name):
 	constructJoint(type, Eigen::Vector3d::UnitZ());
 }
 
-inline void Joint::setMimic(const std::string & name, double multiplier, double offset)
+inline void Joint::makeMimic(const std::string & name, double multiplier, double offset)
 {
 	isMimic_ = true;
 	mimicName_ = name;

--- a/src/Joint.h
+++ b/src/Joint.h
@@ -100,6 +100,15 @@ public:
 		*/
 	Joint(Type type, bool forward, std::string name);
 
+	/**
+	 * Specify mimic information.
+	 *
+	 * @param name Name of the joint that will be mimiced.
+	 * @param multiplier Mimic multiplier
+	 * @param offset Mimic offset
+	 */
+	void set_mimic(const std::string & name, double multiplier, double offset);
+
 	/// @return Joint type.
 	Type type() const
 	{
@@ -147,6 +156,30 @@ public:
 	const std::string& name() const
 	{
 		return name_;
+	}
+
+	/// @return True if the joint is a mimic joint
+	bool is_mimic() const
+	{
+		return is_mimic_;
+	}
+
+	/// @return Mimiced name
+	const std::string& mimic_name() const
+	{
+		return mimic_name_;
+	}
+
+	/// @return Mimic multiplier
+	double mimic_multiplier() const
+	{
+		return mimic_multiplier_;
+	}
+
+	/// @return Mimic offset
+	double mimic_offset() const
+	{
+		return mimic_offset_;
 	}
 
 	/// @return Joint motion subspace in successor frame coordinate.
@@ -244,6 +277,11 @@ private:
 	int dof_;
 
 	std::string name_;
+
+	bool is_mimic_ = false;
+	std::string mimic_name_ = "";
+	double mimic_multiplier_ = 1.0;
+	double mimic_offset_ = 0.0;
 };
 
 
@@ -308,6 +346,14 @@ inline Joint::Joint(Type type,	bool forward, std::string name):
 	name_(name)
 {
 	constructJoint(type, Eigen::Vector3d::UnitZ());
+}
+
+inline void Joint::set_mimic(const std::string & name, double multiplier, double offset)
+{
+	is_mimic_ = true;
+	mimic_name_ = name;
+	mimic_multiplier_ = multiplier;
+	mimic_offset_ = offset;
 }
 
 
@@ -416,7 +462,15 @@ inline sva::MotionVecd Joint::tanAccel(const std::vector<double>& alphaD) const
 
 inline std::vector<double> Joint::zeroParam() const
 {
-	return ZeroParam(type_);
+	auto q = ZeroParam(type_);
+	if(is_mimic_)
+	{
+		for(auto & qi : q)
+		{
+			qi += mimic_offset_;
+		}
+	}
+	return q;
 }
 
 

--- a/src/Joint.h
+++ b/src/Joint.h
@@ -101,7 +101,9 @@ public:
 	Joint(Type type, bool forward, std::string name);
 
 	/**
-	 * Specify mimic information.
+	 * Make the joint mimic and specify mimic information.
+	 *
+	 * This change cannot be reversed.
 	 *
 	 * @param name Name of the joint that will be mimiced.
 	 * @param multiplier Mimic multiplier


### PR DESCRIPTION
This PR makes it possible to store mimic joint information in a `Joint` object. 

By itself, the information is not very useful in RBDyn and there is currently no way to enforce the mimic relationship in `MultiBodyConfig` for example.

See jrl-umi3218/Tasks#13 for usage in control.

