### PR TITLE
Fix python bindings

### DIFF
--- a/binding/python/generate.py
+++ b/binding/python/generate.py
@@ -246,7 +246,7 @@ def build_mb(mb):
                 is_const=True, throw=[out_ex], custom_name='bodyIndexByName')
 
   mb.add_method('sJointIndexByName', retval('int'), [param('const std::string&', 'name')],
-                is_const=True, throw=[out_ex], custom_name='jointIndexById')
+                is_const=True, throw=[out_ex], custom_name='jointIndexByName')
 
 
 


### PR DESCRIPTION
This is a just a typo fix: I forgot to remove a reference to "Id" in the legacy python bindings during the great ID removal.

I open this pull request in case something else comes up and needs to be added.