### PR TITLE
Using acceleration in the integration of joint position.

### DIFF
--- a/src/EulerIntegration.cpp
+++ b/src/EulerIntegration.cpp
@@ -25,7 +25,31 @@
 
 namespace
 {
-	/** Compute the sum of the first terms of the Magnus expansion of \Omega such that
+	namespace detail
+	{
+		double constexpr sqrtNewtonRaphson(double x, double curr, double prev)
+		{
+			return curr == prev
+				? curr
+				: sqrtNewtonRaphson(x, 0.5 * (curr + x / curr), curr);
+		}
+
+		/**
+		* Constexpr version of the square root
+		* Return value:
+		*   - For a finite and non-negative value of "x", returns an approximation for the square root of "x"
+		*   - Otherwise, returns NaN
+		* Copied from https://stackoverflow.com/a/34134071
+		*/
+		double constexpr sqrt(double x)
+		{
+			return x >= 0 && x < std::numeric_limits<double>::infinity()
+				? sqrtNewtonRaphson(x, x, 0)
+				: std::numeric_limits<double>::quiet_NaN();
+		}
+	}
+
+		/** Compute the sum of the first terms of the Magnus expansion of \Omega such that
 		* q' = q*exp(\Omega) is the quaternion obtained after applying a constant acceleration
 		* rotation wD for a duration step, while starting with a velocity w
 		*/
@@ -41,14 +65,14 @@ namespace
 		return O1 + O2 + O3;
 	}
 
-	/** sinus cardinal: sin(x)/x 
+		/** sinus cardinal: sin(x)/x
 		* Code adapted from boost::math::detail::sinc
 		*/
 	double sinc(double x)
 	{
-		const double taylor_0_bound = std::numeric_limits<double>::epsilon();
-		const double taylor_2_bound = sqrt(taylor_0_bound);
-		const double taylor_n_bound = sqrt(taylor_2_bound);
+		constexpr double taylor_0_bound = std::numeric_limits<double>::epsilon();
+		constexpr double taylor_2_bound = detail::sqrt(taylor_0_bound);
+		constexpr double taylor_n_bound = detail::sqrt(taylor_2_bound);
 
 		if (std::abs(x) >= taylor_n_bound)
 		{

--- a/src/EulerIntegration.cpp
+++ b/src/EulerIntegration.cpp
@@ -23,86 +23,142 @@
 #include "MultiBody.h"
 #include "MultiBodyConfig.h"
 
+namespace
+{
+  /** Compute the sum of the first terms of the Magnus expansion of \Omega such that
+    * q' = q*exp(\Omega) is the quaternion obtained after applying a constant acceleration
+    * rotation wD for a duration step, while starting with a velocity w
+    */
+  Eigen::Vector3d magnusExpansion(const Eigen::Vector3d& w, const Eigen::Vector3d& wD, double step)
+  {
+    double step2 = step*step;
+
+    Eigen::Vector3d w1 = w + wD * step;
+    Eigen::Vector3d O1 = (w + w1)*step / 2;
+    Eigen::Vector3d O2 = w1.cross(w) * step2 / 12;
+    Eigen::Vector3d O3 = wD.cross(O2) * step2 / 20;
+
+    return O1 + O2 + O3;
+  }
+
+  /** sinus cardinal: sin(x)/x 
+    * Code adapted from boost::math::detail::sinc
+    */
+  double sinc(double x)
+  {
+    const double taylor_0_bound = std::numeric_limits<double>::epsilon();
+    const double taylor_2_bound = sqrt(taylor_0_bound);
+    const double taylor_n_bound = sqrt(taylor_2_bound);
+
+    if (abs(x) >= taylor_n_bound)
+    {
+      return(std::sin(x) / x);
+    }
+    else
+    {
+      // approximation by taylor series in x at 0 up to order 0
+      double result = 1;
+
+      if (abs(x) >= taylor_0_bound)
+      {
+        double x2 = x*x;
+
+        // approximation by taylor series in x at 0 up to order 2
+        result -= x2 / 6;
+
+        if (abs(x) >= taylor_2_bound)
+        {
+          // approximation by taylor series in x at 0 up to order 4
+          result += (x2*x2) / 120;
+        }
+      }
+
+      return(result);
+    }
+  }
+}
+
 namespace rbd
 {
 
-Eigen::Matrix<double, 4, 3> angularVelToQuatVel(const std::vector<double>& q)
-{
-	return 0.5*(Eigen::Matrix<double, 4, 3>() <<
-		-q[1], -q[2], -q[3],
-		q[0], -q[3], q[2],
-		q[3], q[0], -q[1],
-		-q[2], q[1], q[0]).finished();
-}
-
-
-
 void eulerJointIntegration(Joint::Type type, const std::vector<double>& alpha,
-	double step, std::vector<double>& q)
+  const std::vector<double>& alphaD,  double step, std::vector<double>& q)
 {
-	switch(type)
-	{
-		case Joint::Rev:
-		case Joint::Prism:
-		{
-			q[0] += alpha[0]*step;
-			break;
-		}
+  double step2 = step*step;
+  switch (type)
+  {
+  case Joint::Rev:
+  case Joint::Prism:
+  {
+    q[0] += alpha[0] * step + alphaD[0] * step2 / 2;
+    break;
+  }
 
-		/// @todo manage reverse joint
-		case Joint::Planar:
-		{
-			double q1Step = q[2]*alpha[0] + alpha[1];
-			double q2Step = -q[1]*alpha[0] + alpha[2];
-			q[0] += alpha[0]*step;
-			q[1] += q1Step*step;
-			q[2] += q2Step*step;
-			break;
-		}
+  /// @todo manage reverse joint
+  case Joint::Planar:
+  {
+    // This is the old implementation akin to x' = x + v*step 
+    // (i.e. we don't take the acceleration into account)
+    /// @todo us the acceleration
+    double q1Step = q[2] * alpha[0] + alpha[1];
+    double q2Step = -q[1] * alpha[0] + alpha[2];
+    q[0] += alpha[0] * step;
+    q[1] += q1Step*step;
+    q[2] += q2Step*step;
+    break;
+  }
 
-		case Joint::Cylindrical:
-		{
-			q[0] += alpha[0]*step;
-			q[1] += alpha[1]*step;
-			break;
-		}
+  case Joint::Cylindrical:
+  {
+    q[0] += alpha[0] * step + alphaD[0] * step2 / 2;
+    q[1] += alpha[1] * step + alphaD[1] * step2 / 2;
+    break;
+  }
 
-		/// @todo manage reverse joint
-		case Joint::Free:
-		{
-			Eigen::Vector3d v;
-			v << alpha[3], alpha[4], alpha[5];
-			// v is in FS coordinate. We have to put it back in FP coordinate.
-			v = QuatToE(q).transpose()*v;
+  /// @todo manage reverse joint
+  case Joint::Free:
+  {
+    Eigen::Vector3d v;
+    Eigen::Vector3d a;
+    v << alpha[3], alpha[4], alpha[5];
+    a << alphaD[3], alphaD[4], alphaD[5];
+    // v and a are in FS coordinate. We have to put it back in FP coordinate.
+    v = QuatToE(q).transpose()*v;
+    a = QuatToE(q).transpose()*a;
 
-			q[4] += v[0]*step;
-			q[5] += v[1]*step;
-			q[6] += v[2]*step;
+    q[4] += v[0] * step + a[0] * step2 / 2;
+    q[5] += v[1] * step + a[1] * step2 / 2;
+    q[6] += v[2] * step + a[2] * step2 / 2;
 
-			// don't break, we go in spherical
-		}
-		/// @todo manage reverse joint
-		case Joint::Spherical:
-		{
-			Eigen::Vector4d qi;
-			Eigen::Vector3d w;
-			qi << q[0], q[1], q[2], q[3];
-			w << alpha[0], alpha[1], alpha[2];
+    // don't break, we go in spherical
+  }
+  /// @todo manage reverse joint
+  case Joint::Spherical:
+  {
+    Eigen::Quaterniond qi(q[0], q[1], q[2], q[3]);
+    Eigen::Vector3d w(alpha[0], alpha[1], alpha[2]);
+    Eigen::Vector3d wD(alphaD[0], alphaD[1], alphaD[2]);
 
-			qi.noalias() += angularVelToQuatVel(q)*w*step;
-			qi.normalize();
+    //the division by 2 is because we want to compute exp(O/2);
+    Eigen::Vector3d O = magnusExpansion(w, wD, step) / 2;
+    double n = O.norm();
+    double s = sinc(n);
+    Eigen::Quaterniond qexp(std::cos(n), s*O.x(), s*O.y(), s*O.z());
 
-			q[0] = qi(0);
-			q[1] = qi(1);
-			q[2] = qi(2);
-			q[3] = qi(3);
-			break;
-		}
+    qi *= qexp;
+    qi.normalize(); //This step should not be necessary but we keep it for robustness
 
-		case Joint::Fixed:
-		default:
-		;
-	}
+    q[0] = qi.w();
+    q[1] = qi.x();
+    q[2] = qi.y();
+    q[3] = qi.z();
+    break;
+  }
+
+  case Joint::Fixed:
+  default:
+    ;
+  }
 }
 
 void eulerIntegration(const MultiBody& mb, MultiBodyConfig& mbc, double step)
@@ -112,7 +168,7 @@ void eulerIntegration(const MultiBody& mb, MultiBodyConfig& mbc, double step)
 	// integrate
 	for(std::size_t i = 0; i < joints.size(); ++i)
 	{
-		eulerJointIntegration(joints[i].type(), mbc.alpha[i], step, mbc.q[i]);
+    eulerJointIntegration(joints[i].type(), mbc.alpha[i], mbc.alphaD[i], step, mbc.q[i]);
 		for(int j = 0; j < joints[i].dof(); ++j)
 		{
 			mbc.alpha[i][j] += mbc.alphaD[i][j]*step;

--- a/src/EulerIntegration.cpp
+++ b/src/EulerIntegration.cpp
@@ -25,140 +25,140 @@
 
 namespace
 {
-  /** Compute the sum of the first terms of the Magnus expansion of \Omega such that
-    * q' = q*exp(\Omega) is the quaternion obtained after applying a constant acceleration
-    * rotation wD for a duration step, while starting with a velocity w
-    */
-  Eigen::Vector3d magnusExpansion(const Eigen::Vector3d& w, const Eigen::Vector3d& wD, double step)
-  {
-    double step2 = step*step;
+	/** Compute the sum of the first terms of the Magnus expansion of \Omega such that
+		* q' = q*exp(\Omega) is the quaternion obtained after applying a constant acceleration
+		* rotation wD for a duration step, while starting with a velocity w
+		*/
+	Eigen::Vector3d magnusExpansion(const Eigen::Vector3d& w, const Eigen::Vector3d& wD, double step)
+	{
+		double step2 = step*step;
 
-    Eigen::Vector3d w1 = w + wD * step;
-    Eigen::Vector3d O1 = (w + w1)*step / 2;
-    Eigen::Vector3d O2 = w1.cross(w) * step2 / 12;
-    Eigen::Vector3d O3 = wD.cross(O2) * step2 / 20;
+		Eigen::Vector3d w1 = w + wD * step;
+		Eigen::Vector3d O1 = (w + w1)*step / 2;
+		Eigen::Vector3d O2 = w1.cross(w) * step2 / 12;
+		Eigen::Vector3d O3 = wD.cross(O2) * step2 / 20;
 
-    return O1 + O2 + O3;
-  }
+		return O1 + O2 + O3;
+	}
 
-  /** sinus cardinal: sin(x)/x 
-    * Code adapted from boost::math::detail::sinc
-    */
-  double sinc(double x)
-  {
-    const double taylor_0_bound = std::numeric_limits<double>::epsilon();
-    const double taylor_2_bound = sqrt(taylor_0_bound);
-    const double taylor_n_bound = sqrt(taylor_2_bound);
+	/** sinus cardinal: sin(x)/x 
+		* Code adapted from boost::math::detail::sinc
+		*/
+	double sinc(double x)
+	{
+		const double taylor_0_bound = std::numeric_limits<double>::epsilon();
+		const double taylor_2_bound = sqrt(taylor_0_bound);
+		const double taylor_n_bound = sqrt(taylor_2_bound);
 
-    if (std::abs(x) >= taylor_n_bound)
-    {
-      return(std::sin(x) / x);
-    }
-    else
-    {
-      // approximation by taylor series in x at 0 up to order 0
-      double result = 1;
+		if (std::abs(x) >= taylor_n_bound)
+		{
+			return(std::sin(x) / x);
+		}
+		else
+		{
+			// approximation by taylor series in x at 0 up to order 0
+			double result = 1;
 
-      if (std::abs(x) >= taylor_0_bound)
-      {
-        double x2 = x*x;
+			if (std::abs(x) >= taylor_0_bound)
+			{
+				double x2 = x*x;
 
-        // approximation by taylor series in x at 0 up to order 2
-        result -= x2 / 6;
+				// approximation by taylor series in x at 0 up to order 2
+				result -= x2 / 6;
 
-        if (std::abs(x) >= taylor_2_bound)
-        {
-          // approximation by taylor series in x at 0 up to order 4
-          result += (x2*x2) / 120;
-        }
-      }
+				if (std::abs(x) >= taylor_2_bound)
+				{
+					// approximation by taylor series in x at 0 up to order 4
+					result += (x2*x2) / 120;
+				}
+			}
 
-      return(result);
-    }
-  }
+			return(result);
+		}
+	}
 }
 
 namespace rbd
 {
 
 void eulerJointIntegration(Joint::Type type, const std::vector<double>& alpha,
-  const std::vector<double>& alphaD,  double step, std::vector<double>& q)
+	const std::vector<double>& alphaD,  double step, std::vector<double>& q)
 {
-  double step2 = step*step;
-  switch (type)
-  {
-  case Joint::Rev:
-  case Joint::Prism:
-  {
-    q[0] += alpha[0] * step + alphaD[0] * step2 / 2;
-    break;
-  }
+	double step2 = step*step;
+	switch (type)
+	{
+	case Joint::Rev:
+	case Joint::Prism:
+	{
+		q[0] += alpha[0] * step + alphaD[0] * step2 / 2;
+		break;
+	}
 
-  /// @todo manage reverse joint
-  case Joint::Planar:
-  {
-    // This is the old implementation akin to x' = x + v*step 
-    // (i.e. we don't take the acceleration into account)
-    /// @todo us the acceleration
-    double q1Step = q[2] * alpha[0] + alpha[1];
-    double q2Step = -q[1] * alpha[0] + alpha[2];
-    q[0] += alpha[0] * step;
-    q[1] += q1Step*step;
-    q[2] += q2Step*step;
-    break;
-  }
+	/// @todo manage reverse joint
+	case Joint::Planar:
+	{
+		// This is the old implementation akin to x' = x + v*step 
+		// (i.e. we don't take the acceleration into account)
+		/// @todo us the acceleration
+		double q1Step = q[2] * alpha[0] + alpha[1];
+		double q2Step = -q[1] * alpha[0] + alpha[2];
+		q[0] += alpha[0] * step;
+		q[1] += q1Step*step;
+		q[2] += q2Step*step;
+		break;
+	}
 
-  case Joint::Cylindrical:
-  {
-    q[0] += alpha[0] * step + alphaD[0] * step2 / 2;
-    q[1] += alpha[1] * step + alphaD[1] * step2 / 2;
-    break;
-  }
+	case Joint::Cylindrical:
+	{
+		q[0] += alpha[0] * step + alphaD[0] * step2 / 2;
+		q[1] += alpha[1] * step + alphaD[1] * step2 / 2;
+		break;
+	}
 
-  /// @todo manage reverse joint
-  case Joint::Free:
-  {
-    Eigen::Vector3d v;
-    Eigen::Vector3d a;
-    v << alpha[3], alpha[4], alpha[5];
-    a << alphaD[3], alphaD[4], alphaD[5];
-    // v and a are in FS coordinate. We have to put it back in FP coordinate.
-    v = QuatToE(q).transpose()*v;
-    a = QuatToE(q).transpose()*a;
+	/// @todo manage reverse joint
+	case Joint::Free:
+	{
+		Eigen::Vector3d v;
+		Eigen::Vector3d a;
+		v << alpha[3], alpha[4], alpha[5];
+		a << alphaD[3], alphaD[4], alphaD[5];
+		// v and a are in FS coordinate. We have to put it back in FP coordinate.
+		v = QuatToE(q).transpose()*v;
+		a = QuatToE(q).transpose()*a;
 
-    q[4] += v[0] * step + a[0] * step2 / 2;
-    q[5] += v[1] * step + a[1] * step2 / 2;
-    q[6] += v[2] * step + a[2] * step2 / 2;
+		q[4] += v[0] * step + a[0] * step2 / 2;
+		q[5] += v[1] * step + a[1] * step2 / 2;
+		q[6] += v[2] * step + a[2] * step2 / 2;
 
-    // don't break, we go in spherical
-  }
-  /// @todo manage reverse joint
-  case Joint::Spherical:
-  {
-    Eigen::Quaterniond qi(q[0], q[1], q[2], q[3]);
-    Eigen::Vector3d w(alpha[0], alpha[1], alpha[2]);
-    Eigen::Vector3d wD(alphaD[0], alphaD[1], alphaD[2]);
+		// don't break, we go in spherical
+	}
+	/// @todo manage reverse joint
+	case Joint::Spherical:
+	{
+		Eigen::Quaterniond qi(q[0], q[1], q[2], q[3]);
+		Eigen::Vector3d w(alpha[0], alpha[1], alpha[2]);
+		Eigen::Vector3d wD(alphaD[0], alphaD[1], alphaD[2]);
 
-    //the division by 2 is because we want to compute exp(O/2);
-    Eigen::Vector3d O = magnusExpansion(w, wD, step) / 2;
-    double n = O.norm();
-    double s = sinc(n);
-    Eigen::Quaterniond qexp(std::cos(n), s*O.x(), s*O.y(), s*O.z());
+		//the division by 2 is because we want to compute exp(O/2);
+		Eigen::Vector3d O = magnusExpansion(w, wD, step) / 2;
+		double n = O.norm();
+		double s = sinc(n);
+		Eigen::Quaterniond qexp(std::cos(n), s*O.x(), s*O.y(), s*O.z());
 
-    qi *= qexp;
-    qi.normalize(); //This step should not be necessary but we keep it for robustness
+		qi *= qexp;
+		qi.normalize(); //This step should not be necessary but we keep it for robustness
 
-    q[0] = qi.w();
-    q[1] = qi.x();
-    q[2] = qi.y();
-    q[3] = qi.z();
-    break;
-  }
+		q[0] = qi.w();
+		q[1] = qi.x();
+		q[2] = qi.y();
+		q[3] = qi.z();
+		break;
+	}
 
-  case Joint::Fixed:
-  default:
-    ;
-  }
+	case Joint::Fixed:
+	default:
+		;
+	}
 }
 
 void eulerIntegration(const MultiBody& mb, MultiBodyConfig& mbc, double step)
@@ -168,7 +168,7 @@ void eulerIntegration(const MultiBody& mb, MultiBodyConfig& mbc, double step)
 	// integrate
 	for(std::size_t i = 0; i < joints.size(); ++i)
 	{
-    eulerJointIntegration(joints[i].type(), mbc.alpha[i], mbc.alphaD[i], step, mbc.q[i]);
+		eulerJointIntegration(joints[i].type(), mbc.alpha[i], mbc.alphaD[i], step, mbc.q[i]);
 		for(int j = 0; j < joints[i].dof(); ++j)
 		{
 			mbc.alpha[i][j] += mbc.alphaD[i][j]*step;

--- a/src/EulerIntegration.cpp
+++ b/src/EulerIntegration.cpp
@@ -50,7 +50,7 @@ namespace
     const double taylor_2_bound = sqrt(taylor_0_bound);
     const double taylor_n_bound = sqrt(taylor_2_bound);
 
-    if (abs(x) >= taylor_n_bound)
+    if (std::abs(x) >= taylor_n_bound)
     {
       return(std::sin(x) / x);
     }
@@ -59,14 +59,14 @@ namespace
       // approximation by taylor series in x at 0 up to order 0
       double result = 1;
 
-      if (abs(x) >= taylor_0_bound)
+      if (std::abs(x) >= taylor_0_bound)
       {
         double x2 = x*x;
 
         // approximation by taylor series in x at 0 up to order 2
         result -= x2 / 6;
 
-        if (abs(x) >= taylor_2_bound)
+        if (std::abs(x) >= taylor_2_bound)
         {
           // approximation by taylor series in x at 0 up to order 4
           result += (x2*x2) / 120;

--- a/src/EulerIntegration.h
+++ b/src/EulerIntegration.h
@@ -34,12 +34,13 @@ struct MultiBodyConfig;
 /**
 	* Integrate joint configuration.
 	* @param type Joint type.
-	* @param alpha Joint velocity vector.
+  * @param alpha Joint velocity vector.
+  * @param alphaD Joint acceleration vector.
 	* @param step Integration step.
 	* @param q Joint configuration vector.
 	*/
 RBDYN_DLLAPI void eulerJointIntegration(Joint::Type type, const std::vector<double>& alpha,
-	double step, std::vector<double>& q);
+  const std::vector<double>& alphaD,  double step, std::vector<double>& q);
 
 /**
 	* Use the euler method to integrate.

--- a/src/EulerIntegration.h
+++ b/src/EulerIntegration.h
@@ -34,13 +34,13 @@ struct MultiBodyConfig;
 /**
 	* Integrate joint configuration.
 	* @param type Joint type.
-  * @param alpha Joint velocity vector.
-  * @param alphaD Joint acceleration vector.
+	* @param alpha Joint velocity vector.
+	* @param alphaD Joint acceleration vector.
 	* @param step Integration step.
 	* @param q Joint configuration vector.
 	*/
 RBDYN_DLLAPI void eulerJointIntegration(Joint::Type type, const std::vector<double>& alpha,
-  const std::vector<double>& alphaD,  double step, std::vector<double>& q);
+	const std::vector<double>& alphaD,  double step, std::vector<double>& q);
 
 /**
 	* Use the euler method to integrate.

--- a/tests/AlgoTest.cpp
+++ b/tests/AlgoTest.cpp
@@ -429,14 +429,14 @@ BOOST_AUTO_TEST_CASE(EulerTest)
 	using namespace std;
 	using namespace Eigen;
 	using namespace rbd;
-  namespace cst = boost::math::constants;
+	namespace cst = boost::math::constants;
 
 	// 1 dof joint
 
 	// static
 	vector<double> q = {0.};
 
-  eulerJointIntegration(Joint::Rev, { 0. }, { 0. }, 1., q);
+	eulerJointIntegration(Joint::Rev, { 0. }, { 0. }, 1., q);
 
 	BOOST_CHECK_EQUAL(q[0], 0.);
 
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(EulerTest)
 
 
 	// X unit rot
-  const double pi = cst::pi<double>();
+	const double pi = cst::pi<double>();
 	q = {1., 0., 0., 0., 0., 0., 0.};
 	goalQ = {std::cos(pi/4), std::sin(pi/4), 0., 0., 0., 0., 0.},
 	eulerJointIntegration(Joint::Free, {pi/2., 0., 0., 0., 0., 0.}, { 0., 0., 0., 0., 0., 0. }, 1., q);
@@ -471,7 +471,7 @@ BOOST_AUTO_TEST_CASE(EulerTest)
 	// planar
 	q = {0., 0., 0.};
 	goalQ = {1., 1., 1.};
-  eulerJointIntegration(Joint::Planar, { 1., 1., 1. }, { 0., 0., 0. }, 1., q);
+	eulerJointIntegration(Joint::Planar, { 1., 1., 1. }, { 0., 0., 0. }, 1., q);
 	BOOST_CHECK_EQUAL_COLLECTIONS(q.begin(), q.end(), goalQ.begin(), goalQ.end());
 }
 
@@ -493,7 +493,7 @@ double testEulerInteg(rbd::Joint::Type jType, const Eigen::Vector3d& axis,
 	for(int i = 0; i < j.dof(); ++i)
 	{
 		alphaVec[i] = alpha[i];
-    alphaDVec[i] = 0.;
+		alphaDVec[i] = 0.;
 	}
 
 	sva::PTransformd initPos(j.pose(qVec));
@@ -662,91 +662,91 @@ BOOST_AUTO_TEST_CASE(FAGravityTest)
 
 BOOST_AUTO_TEST_CASE(IKTest)
 {
-  using namespace Eigen;
-  rbd::MultiBody mb;
-  rbd::MultiBodyConfig mbc;
-  rbd::MultiBodyGraph mbg;
+	using namespace Eigen;
+	rbd::MultiBody mb;
+	rbd::MultiBodyConfig mbc;
+	rbd::MultiBodyGraph mbg;
 
-  std::tie(mb, mbc, mbg) = makeXYZarm();
+	std::tie(mb, mbc, mbg) = makeXYZarm();
 
-  rbd::InverseKinematics ik(mb, 3);
+	rbd::InverseKinematics ik(mb, 3);
 
-  rbd::forwardKinematics(mb, mbc);
-  rbd::forwardVelocity(mb, mbc);
+	rbd::forwardKinematics(mb, mbc);
+	rbd::forwardVelocity(mb, mbc);
 
-  sva::PTransformd target(mbc.bodyPosW[3]);
-  BOOST_CHECK(ik.inverseKinematics(mb, mbc, target));
+	sva::PTransformd target(mbc.bodyPosW[3]);
+	BOOST_CHECK(ik.inverseKinematics(mb, mbc, target));
 
-  Eigen::Vector3d pos_vec(mbc.q[1][0], mbc.q[2][0], mbc.q[3][0]);
-  Eigen::Vector3d solution(0, 0, 0);
-  BOOST_CHECK_SMALL((pos_vec - solution).norm(), TOL);
+	Eigen::Vector3d pos_vec(mbc.q[1][0], mbc.q[2][0], mbc.q[3][0]);
+	Eigen::Vector3d solution(0, 0, 0);
+	BOOST_CHECK_SMALL((pos_vec - solution).norm(), TOL);
 
-  solution[0] = 1.;
-  mbc.q[1][0] = 1.;
-  rbd::forwardKinematics(mb, mbc);
-  target = sva::PTransformd(mbc.bodyPosW[3]);
-  mbc.q[1][0] = 0.;
-  rbd::forwardKinematics(mb, mbc);
-  BOOST_CHECK(ik.inverseKinematics(mb, mbc, target));
-  pos_vec = Eigen::Vector3d(mbc.q[1][0], mbc.q[2][0], mbc.q[3][0]);
-  BOOST_CHECK_SMALL((pos_vec - solution).norm(), TOL);
+	solution[0] = 1.;
+	mbc.q[1][0] = 1.;
+	rbd::forwardKinematics(mb, mbc);
+	target = sva::PTransformd(mbc.bodyPosW[3]);
+	mbc.q[1][0] = 0.;
+	rbd::forwardKinematics(mb, mbc);
+	BOOST_CHECK(ik.inverseKinematics(mb, mbc, target));
+	pos_vec = Eigen::Vector3d(mbc.q[1][0], mbc.q[2][0], mbc.q[3][0]);
+	BOOST_CHECK_SMALL((pos_vec - solution).norm(), TOL);
 
-  solution = Eigen::Vector3d(0., 1., 0.);
-  mbc.q[1][0] = 0.;
-  mbc.q[2][0] = 1.;
-  mbc.q[3][0] = 0.;
-  rbd::forwardKinematics(mb, mbc);
-  target = sva::PTransformd(mbc.bodyPosW[3]);
-  mbc.q[2][0] = 0.;
-  rbd::forwardKinematics(mb, mbc);
-  BOOST_CHECK(ik.inverseKinematics(mb, mbc, target));
-  pos_vec = Eigen::Vector3d(mbc.q[1][0], mbc.q[2][0], mbc.q[3][0]);
-  BOOST_CHECK_SMALL((pos_vec - solution).norm(), TOL);
+	solution = Eigen::Vector3d(0., 1., 0.);
+	mbc.q[1][0] = 0.;
+	mbc.q[2][0] = 1.;
+	mbc.q[3][0] = 0.;
+	rbd::forwardKinematics(mb, mbc);
+	target = sva::PTransformd(mbc.bodyPosW[3]);
+	mbc.q[2][0] = 0.;
+	rbd::forwardKinematics(mb, mbc);
+	BOOST_CHECK(ik.inverseKinematics(mb, mbc, target));
+	pos_vec = Eigen::Vector3d(mbc.q[1][0], mbc.q[2][0], mbc.q[3][0]);
+	BOOST_CHECK_SMALL((pos_vec - solution).norm(), TOL);
 
-  solution = Eigen::Vector3d::Random();
-  mbc.q[1][0] = solution[0];
-  mbc.q[2][0] = solution[1];
-  mbc.q[3][0] = solution[2];
-  rbd::forwardKinematics(mb, mbc);
-  target = sva::PTransformd(mbc.bodyPosW[3]);
-  mbc.zero(mb);
-  rbd::forwardKinematics(mb, mbc);
-  BOOST_CHECK(ik.inverseKinematics(mb, mbc, target));
-  pos_vec = Eigen::Vector3d(mbc.q[1][0], mbc.q[2][0], mbc.q[3][0]);
-  BOOST_CHECK_SMALL((pos_vec - solution).norm(), TOL);
+	solution = Eigen::Vector3d::Random();
+	mbc.q[1][0] = solution[0];
+	mbc.q[2][0] = solution[1];
+	mbc.q[3][0] = solution[2];
+	rbd::forwardKinematics(mb, mbc);
+	target = sva::PTransformd(mbc.bodyPosW[3]);
+	mbc.zero(mb);
+	rbd::forwardKinematics(mb, mbc);
+	BOOST_CHECK(ik.inverseKinematics(mb, mbc, target));
+	pos_vec = Eigen::Vector3d(mbc.q[1][0], mbc.q[2][0], mbc.q[3][0]);
+	BOOST_CHECK_SMALL((pos_vec - solution).norm(), TOL);
 }
 
 BOOST_AUTO_TEST_CASE(FailureIKTest)
 {
-  using namespace Eigen;
-  rbd::MultiBody mb;
-  rbd::MultiBodyConfig mbc;
-  rbd::MultiBodyGraph mbg;
+	using namespace Eigen;
+	rbd::MultiBody mb;
+	rbd::MultiBodyConfig mbc;
+	rbd::MultiBodyGraph mbg;
 
-  std::tie(mb, mbc, mbg) = makeXYZarm();
+	std::tie(mb, mbc, mbg) = makeXYZarm();
 
-  rbd::InverseKinematics ik(mb, 3);
+	rbd::InverseKinematics ik(mb, 3);
 
-  rbd::forwardKinematics(mb, mbc);
-  rbd::forwardVelocity(mb, mbc);
+	rbd::forwardKinematics(mb, mbc);
+	rbd::forwardVelocity(mb, mbc);
 
-  // This target is outside the reach of the arm
-  sva::PTransformd target(sva::RotX(M_PI/2), Eigen::Vector3d(0., 0.5, 2.5));
-  BOOST_CHECK(!ik.inverseKinematics(mb, mbc, target));
+	// This target is outside the reach of the arm
+	sva::PTransformd target(sva::RotX(M_PI/2), Eigen::Vector3d(0., 0.5, 2.5));
+	BOOST_CHECK(!ik.inverseKinematics(mb, mbc, target));
 
-  Eigen::VectorXd q_target(mb.nrParams());
-  Eigen::VectorXd q(mb.nrParams());
+	Eigen::VectorXd q_target(mb.nrParams());
+	Eigen::VectorXd q(mb.nrParams());
 
-  q_target << M_PI/2, 0, 0;
-  rbd::paramToVector(mbc.q, q);
+	q_target << M_PI/2, 0, 0;
+	rbd::paramToVector(mbc.q, q);
 
-  BOOST_CHECK_SMALL((q_target - q).norm(), TOL);
+	BOOST_CHECK_SMALL((q_target - q).norm(), TOL);
 
-  /* This target is reachable, but IK will fail if given
-   * a too low maximum number of iterations */
-  ik.max_iterations_ = 10;
-  sva::PTransformd reachable_target(sva::RotX(-M_PI/2), Eigen::Vector3d(0., 0.5, -2.));
-  BOOST_CHECK(!ik.inverseKinematics(mb, mbc, reachable_target));
-  ik.max_iterations_ = 40;
-  BOOST_CHECK(ik.inverseKinematics(mb, mbc, reachable_target));
+	/* This target is reachable, but IK will fail if given
+	 * a too low maximum number of iterations */
+	ik.max_iterations_ = 10;
+	sva::PTransformd reachable_target(sva::RotX(-M_PI/2), Eigen::Vector3d(0., 0.5, -2.));
+	BOOST_CHECK(!ik.inverseKinematics(mb, mbc, reachable_target));
+	ik.max_iterations_ = 40;
+	BOOST_CHECK(ik.inverseKinematics(mb, mbc, reachable_target));
 }

--- a/tests/AlgoTest.cpp
+++ b/tests/AlgoTest.cpp
@@ -461,9 +461,10 @@ BOOST_AUTO_TEST_CASE(EulerTest)
 
 
 	// X unit rot
+  const double pi = cst::pi<double>();
 	q = {1., 0., 0., 0., 0., 0., 0.};
-	goalQ = {std::sqrt(2.)/2., std::sqrt(2.)/2., 0., 0., 0., 0., 0.},
-	eulerJointIntegration(Joint::Free, {cst::pi<double>()/2., 0., 0., 0., 0., 0.}, { 0., 0., 0., 0., 0., 0. }, 1., q);
+	goalQ = {std::cos(pi/4), std::sin(pi/4), 0., 0., 0., 0., 0.},
+	eulerJointIntegration(Joint::Free, {pi/2., 0., 0., 0., 0., 0.}, { 0., 0., 0., 0., 0., 0. }, 1., q);
 	BOOST_CHECK_EQUAL_COLLECTIONS(q.begin(), q.end(), goalQ.begin(), goalQ.end());
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ addUnitTest("CoMTest")
 addUnitTest("MomentumTest")
 addUnitTest("IDIMTest")
 addUnitTest("InverseStaticsTest")
+addUnitTest("IntegrationTest")
 
 addBenchmark("JacobianBench")
 addBenchmark("DynamicsBench")

--- a/tests/IntegrationTest.cpp
+++ b/tests/IntegrationTest.cpp
@@ -114,11 +114,15 @@ randQVA(Joint::Type type)
 		a = randVec(2, -1, 1);
 		break;
 	case Joint::Free:
+	{
 		q = randVec(4, -1, 1, true);
 		auto qt = randVec(3, -1, 1);
 		q.insert(q.end(), qt.begin(), qt.end());
 		v = randVec(6, -1, 1);
 		a = randVec(6, -1, 1);
+		break;
+	}
+	default:
 		break;
 	}
 
@@ -175,7 +179,7 @@ void testConstantAccelerationIntegration(Joint::Type type,
 	eulerIntegration(mb, mbc0, step);
 
 	//integrating with constant velocity on small time step
-	const int N = 5000;
+	const int N = 2000;
 	for (int i = 0; i < N; ++i)
 	{
 		eulerIntegration(mb, mbc, step/N);

--- a/tests/IntegrationTest.cpp
+++ b/tests/IntegrationTest.cpp
@@ -1,0 +1,220 @@
+// Copyright 2012-2017 CNRS-UM LIRMM, CNRS-AIST JRL
+//
+// This file is part of RBDyn.
+//
+// RBDyn is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// RBDyn is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with RBDyn.  If not, see <http://www.gnu.org/licenses/>.
+
+// includes
+// std
+#include <iostream>
+#include <vector>
+
+// boost
+#define BOOST_TEST_MODULE JointTest
+#include <boost/test/unit_test.hpp>
+#include <boost/math/constants/constants.hpp>
+
+// SpaceVecAlg
+#include <SpaceVecAlg/SpaceVecAlg>
+
+// RBDyn
+#include "FK.h"
+#include "FV.h"
+#include "Body.h"
+#include "Joint.h"
+#include "MultiBody.h"
+#include "MultiBodyConfig.h"
+#include "MultiBodyGraph.h"
+#include "EulerIntegration.h"
+
+using namespace Eigen;
+using namespace sva;
+using namespace rbd;
+namespace constants = boost::math::constants;
+
+
+/// @return A robot with a single joint specified by the user
+std::tuple<rbd::MultiBody, rbd::MultiBodyConfig, rbd::MultiBodyGraph>
+makeSingleJointRobot(Joint::Type type, const Vector3d& axis = Vector3d::UnitZ())
+{
+  MultiBodyGraph mbg;
+
+  double mass = 1.;
+  Matrix3d I = Matrix3d::Identity();
+  Vector3d h = Vector3d::Zero();
+  RBInertiad rbi(mass, h, I);
+
+  Body b0(rbi, "b0");
+  Body b1(rbi, "b1");
+  mbg.addBody(b0);
+  mbg.addBody(b1);
+ 
+  Joint j0(type,axis,true,"j0");
+  mbg.addJoint(j0);
+
+  PTransformd to(Vector3d(0., 0., 0.));
+  PTransformd from(Vector3d(0., 0., 0.));
+  mbg.linkBodies("b0", to, "b1", from, "j0");
+
+  MultiBody mb = mbg.makeMultiBody("b0", true);
+  MultiBodyConfig mbc(mb);
+  mbc.zero(mb);
+
+  return std::make_tuple(mb, mbc, mbg);
+}
+
+std::vector<double> randVec(int size, double rmin, double rmax, bool normed = false)
+{
+  std::vector<double> v(size, 0);
+  Map<VectorXd> r(&v[0], size, 1);
+  r = (rmax - rmin)*VectorXd::Random(size).cwiseAbs() + VectorXd::Constant(size, rmin);
+
+  if (normed)
+    r.normalize();
+
+  return v;
+}
+
+std::tuple<std::vector<double>, std::vector<double>, std::vector<double>>
+randQVA(Joint::Type type)
+{
+  std::vector<double> q, v, a;
+  switch (type)
+  {
+  case Joint::Rev:
+  case Joint::Prism:
+    q = randVec(1, -1, 1);
+    v = randVec(1, -1, 1);
+    a = randVec(1, -1, 1);
+    break;
+  case Joint::Spherical:
+    q = randVec(4, -1, 1, true);
+    v = randVec(3, -1, 1);
+    a = randVec(3, -1, 1);
+    break;
+  case Joint::Planar:
+    q = randVec(3, -1, 1);
+    v = randVec(3, -1, 1);
+    a = randVec(3, -1, 1);
+    break;
+  case Joint::Cylindrical:
+    q = randVec(2, -1, 1);
+    v = randVec(2, -1, 1);
+    a = randVec(2, -1, 1);
+    break;
+  case Joint::Free:
+    q = randVec(4, -1, 1, true);
+    auto qt = randVec(3, -1, 1);
+    q.insert(q.end(), qt.begin(), qt.end());
+    v = randVec(6, -1, 1);
+    a = randVec(6, -1, 1);
+    break;
+  }
+
+  return std::make_tuple(q, v, a);
+}
+
+void testConstantSpeedIntegration(Joint::Type type, 
+                                  double step,
+                                  const std::vector<double>& q,
+                                  const std::vector<double>& v, 
+                                  const std::vector<double>& q_expected)
+{
+  MultiBody mb;
+  MultiBodyConfig mbc;
+  MultiBodyGraph mbg;
+  std::tie(mb, mbc, mbg) = makeSingleJointRobot(type);
+
+  mbc.q = { {}, q };
+  mbc.alpha = { {}, v };
+  mbc.alphaD = { {}, std::vector<double>(v.size(), 0) };
+  forwardKinematics(mb, mbc);
+
+  eulerIntegration(mb, mbc, step);
+
+  for (size_t i=0; i<q.size(); ++i)
+  { 
+    BOOST_CHECK_CLOSE_FRACTION(q_expected[i], mbc.q[1][i], 1e-8);
+  }
+}
+
+void testConstantAccelerationIntegration(Joint::Type type, 
+                                         double step, 
+                                         const std::vector<double>& q,
+                                         const std::vector<double>& v,
+                                         const std::vector<double>& a)
+{
+  MultiBody mb;
+  MultiBodyConfig mbc;
+  MultiBodyGraph mbg;
+  std::tie(mb, mbc, mbg) = makeSingleJointRobot(type);
+  MultiBodyConfig mbc0(mbc);
+
+  mbc.q = { {}, q };
+  mbc.alpha = { {}, v };
+  mbc.alphaD = { {}, std::vector<double>(v.size(), 0) }; 
+  mbc0.q = { {}, q };
+  mbc0.alpha = { {}, v };
+  mbc0.alphaD = { {}, a };
+
+  forwardKinematics(mb, mbc);
+  forwardKinematics(mb, mbc0);
+
+  //integrating on the whole time step
+  eulerIntegration(mb, mbc0, step);
+
+  //integrating with constant velocity on small time step
+  const int N = 1000;
+  for (int i = 0; i < N; ++i)
+  {
+    eulerIntegration(mb, mbc, step/N);
+    for (size_t j = 0; j < v.size(); ++j)
+      mbc.alpha[1][j] += a[j] * step / N;
+    forwardKinematics(mb, mbc);
+  }
+
+  for (size_t i=0; i<q.size(); ++i)
+  { 
+    BOOST_CHECK_CLOSE_FRACTION(mbc0.q[1][i], mbc.q[1][i], 1e-3);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(JointIntegrationTest)
+{
+  const double pi = constants::pi<double>();
+  const double c2 = std::sqrt(2) / 2;
+
+  testConstantSpeedIntegration(Joint::Rev, 1, { 1 }, { 0.5 }, { 1.5 });
+  testConstantSpeedIntegration(Joint::Prism, 1, { 1 }, { 0.5 }, { 1.5 });
+  testConstantSpeedIntegration(Joint::Spherical, 1, { 1, 0, 0, 0 }, { pi / 2, 0, 0 }, { c2, c2, 0, 0 });
+  testConstantSpeedIntegration(Joint::Spherical, 1, { c2, 0, c2, 0 }, { pi / 2, 0, 0 }, { 0.5, 0.5, 0.5, -0.5 });
+  //testConstantSpeedIntegration(Joint::Planar, 1, { 1 }, { 0.5 }, { 1.5 });
+  testConstantSpeedIntegration(Joint::Cylindrical, 1, { 1, 2 }, { 0.5, 0.25 }, { 1.5, 2.25 });
+  testConstantSpeedIntegration(Joint::Free, 1, { 1, 0, 0, 0, 1, 2, 3 }, { pi / 2, 0, 0, 0.5, 0.25, -0.5 }, { c2, c2, 0, 0, 1.5, 2.25, 2.5 });
+  testConstantSpeedIntegration(Joint::Free, 1, { c2, 0, c2, 0, 1, 2, 3 }, { pi / 2, 0, 0, 0.5, 0.25, -0.5 }, { 0.5, 0.5, 0.5, -0.5, 0.5, 2.25, 2.5 });
+
+  std::vector<double> q, v, a;
+  std::tie(q, v, a) = randQVA(Joint::Rev);
+  testConstantAccelerationIntegration(Joint::Rev, 1, q, v, a);
+  std::tie(q, v, a) = randQVA(Joint::Prism);
+  testConstantAccelerationIntegration(Joint::Prism, 1, q, v, a);
+  std::tie(q, v, a) = randQVA(Joint::Spherical);
+  testConstantAccelerationIntegration(Joint::Spherical, 0.01, q, v, a);
+  //std::tie(q, v, a) = randQVA(Joint::Planar);
+  //testConstantAccelerationIntegration(Joint::Planar, 1, q, v, a);
+  std::tie(q, v, a) = randQVA(Joint::Cylindrical);
+  testConstantAccelerationIntegration(Joint::Cylindrical, 1, q, v, a);
+  std::tie(q, v, a) = randQVA(Joint::Free);
+  testConstantAccelerationIntegration(Joint::Free, 0.01, q, v, a);
+}

--- a/tests/IntegrationTest.cpp
+++ b/tests/IntegrationTest.cpp
@@ -175,7 +175,7 @@ void testConstantAccelerationIntegration(Joint::Type type,
   eulerIntegration(mb, mbc0, step);
 
   //integrating with constant velocity on small time step
-  const int N = 1000;
+  const int N = 5000;
   for (int i = 0; i < N; ++i)
   {
     eulerIntegration(mb, mbc, step/N);

--- a/tests/IntegrationTest.cpp
+++ b/tests/IntegrationTest.cpp
@@ -48,173 +48,173 @@ namespace constants = boost::math::constants;
 std::tuple<rbd::MultiBody, rbd::MultiBodyConfig, rbd::MultiBodyGraph>
 makeSingleJointRobot(Joint::Type type, const Vector3d& axis = Vector3d::UnitZ())
 {
-  MultiBodyGraph mbg;
+	MultiBodyGraph mbg;
 
-  double mass = 1.;
-  Matrix3d I = Matrix3d::Identity();
-  Vector3d h = Vector3d::Zero();
-  RBInertiad rbi(mass, h, I);
+	double mass = 1.;
+	Matrix3d I = Matrix3d::Identity();
+	Vector3d h = Vector3d::Zero();
+	RBInertiad rbi(mass, h, I);
 
-  Body b0(rbi, "b0");
-  Body b1(rbi, "b1");
-  mbg.addBody(b0);
-  mbg.addBody(b1);
+	Body b0(rbi, "b0");
+	Body b1(rbi, "b1");
+	mbg.addBody(b0);
+	mbg.addBody(b1);
  
-  Joint j0(type,axis,true,"j0");
-  mbg.addJoint(j0);
+	Joint j0(type,axis,true,"j0");
+	mbg.addJoint(j0);
 
-  PTransformd to(Vector3d(0., 0., 0.));
-  PTransformd from(Vector3d(0., 0., 0.));
-  mbg.linkBodies("b0", to, "b1", from, "j0");
+	PTransformd to(Vector3d(0., 0., 0.));
+	PTransformd from(Vector3d(0., 0., 0.));
+	mbg.linkBodies("b0", to, "b1", from, "j0");
 
-  MultiBody mb = mbg.makeMultiBody("b0", true);
-  MultiBodyConfig mbc(mb);
-  mbc.zero(mb);
+	MultiBody mb = mbg.makeMultiBody("b0", true);
+	MultiBodyConfig mbc(mb);
+	mbc.zero(mb);
 
-  return std::make_tuple(mb, mbc, mbg);
+	return std::make_tuple(mb, mbc, mbg);
 }
 
 std::vector<double> randVec(int size, double rmin, double rmax, bool normed = false)
 {
-  std::vector<double> v(size, 0);
-  Map<VectorXd> r(&v[0], size, 1);
-  r = (rmax - rmin)*VectorXd::Random(size).cwiseAbs() + VectorXd::Constant(size, rmin);
+	std::vector<double> v(size, 0);
+	Map<VectorXd> r(&v[0], size, 1);
+	r = (rmax - rmin)*VectorXd::Random(size).cwiseAbs() + VectorXd::Constant(size, rmin);
 
-  if (normed)
-    r.normalize();
+	if (normed)
+		r.normalize();
 
-  return v;
+	return v;
 }
 
 std::tuple<std::vector<double>, std::vector<double>, std::vector<double>>
 randQVA(Joint::Type type)
 {
-  std::vector<double> q, v, a;
-  switch (type)
-  {
-  case Joint::Rev:
-  case Joint::Prism:
-    q = randVec(1, -1, 1);
-    v = randVec(1, -1, 1);
-    a = randVec(1, -1, 1);
-    break;
-  case Joint::Spherical:
-    q = randVec(4, -1, 1, true);
-    v = randVec(3, -1, 1);
-    a = randVec(3, -1, 1);
-    break;
-  case Joint::Planar:
-    q = randVec(3, -1, 1);
-    v = randVec(3, -1, 1);
-    a = randVec(3, -1, 1);
-    break;
-  case Joint::Cylindrical:
-    q = randVec(2, -1, 1);
-    v = randVec(2, -1, 1);
-    a = randVec(2, -1, 1);
-    break;
-  case Joint::Free:
-    q = randVec(4, -1, 1, true);
-    auto qt = randVec(3, -1, 1);
-    q.insert(q.end(), qt.begin(), qt.end());
-    v = randVec(6, -1, 1);
-    a = randVec(6, -1, 1);
-    break;
-  }
+	std::vector<double> q, v, a;
+	switch (type)
+	{
+	case Joint::Rev:
+	case Joint::Prism:
+		q = randVec(1, -1, 1);
+		v = randVec(1, -1, 1);
+		a = randVec(1, -1, 1);
+		break;
+	case Joint::Spherical:
+		q = randVec(4, -1, 1, true);
+		v = randVec(3, -1, 1);
+		a = randVec(3, -1, 1);
+		break;
+	case Joint::Planar:
+		q = randVec(3, -1, 1);
+		v = randVec(3, -1, 1);
+		a = randVec(3, -1, 1);
+		break;
+	case Joint::Cylindrical:
+		q = randVec(2, -1, 1);
+		v = randVec(2, -1, 1);
+		a = randVec(2, -1, 1);
+		break;
+	case Joint::Free:
+		q = randVec(4, -1, 1, true);
+		auto qt = randVec(3, -1, 1);
+		q.insert(q.end(), qt.begin(), qt.end());
+		v = randVec(6, -1, 1);
+		a = randVec(6, -1, 1);
+		break;
+	}
 
-  return std::make_tuple(q, v, a);
+	return std::make_tuple(q, v, a);
 }
 
 void testConstantSpeedIntegration(Joint::Type type, 
-                                  double step,
-                                  const std::vector<double>& q,
-                                  const std::vector<double>& v, 
-                                  const std::vector<double>& q_expected)
+																	double step,
+																	const std::vector<double>& q,
+																	const std::vector<double>& v, 
+																	const std::vector<double>& q_expected)
 {
-  MultiBody mb;
-  MultiBodyConfig mbc;
-  MultiBodyGraph mbg;
-  std::tie(mb, mbc, mbg) = makeSingleJointRobot(type);
+	MultiBody mb;
+	MultiBodyConfig mbc;
+	MultiBodyGraph mbg;
+	std::tie(mb, mbc, mbg) = makeSingleJointRobot(type);
 
-  mbc.q = { {}, q };
-  mbc.alpha = { {}, v };
-  mbc.alphaD = { {}, std::vector<double>(v.size(), 0) };
-  forwardKinematics(mb, mbc);
+	mbc.q = { {}, q };
+	mbc.alpha = { {}, v };
+	mbc.alphaD = { {}, std::vector<double>(v.size(), 0) };
+	forwardKinematics(mb, mbc);
 
-  eulerIntegration(mb, mbc, step);
+	eulerIntegration(mb, mbc, step);
 
-  for (size_t i=0; i<q.size(); ++i)
-  { 
-    BOOST_CHECK_CLOSE_FRACTION(q_expected[i], mbc.q[1][i], 1e-8);
-  }
+	for (size_t i=0; i<q.size(); ++i)
+	{ 
+		BOOST_CHECK_CLOSE_FRACTION(q_expected[i], mbc.q[1][i], 1e-8);
+	}
 }
 
 void testConstantAccelerationIntegration(Joint::Type type, 
-                                         double step, 
-                                         const std::vector<double>& q,
-                                         const std::vector<double>& v,
-                                         const std::vector<double>& a)
+																				 double step, 
+																				 const std::vector<double>& q,
+																				 const std::vector<double>& v,
+																				 const std::vector<double>& a)
 {
-  MultiBody mb;
-  MultiBodyConfig mbc;
-  MultiBodyGraph mbg;
-  std::tie(mb, mbc, mbg) = makeSingleJointRobot(type);
-  MultiBodyConfig mbc0(mbc);
+	MultiBody mb;
+	MultiBodyConfig mbc;
+	MultiBodyGraph mbg;
+	std::tie(mb, mbc, mbg) = makeSingleJointRobot(type);
+	MultiBodyConfig mbc0(mbc);
 
-  mbc.q = { {}, q };
-  mbc.alpha = { {}, v };
-  mbc.alphaD = { {}, std::vector<double>(v.size(), 0) }; 
-  mbc0.q = { {}, q };
-  mbc0.alpha = { {}, v };
-  mbc0.alphaD = { {}, a };
+	mbc.q = { {}, q };
+	mbc.alpha = { {}, v };
+	mbc.alphaD = { {}, std::vector<double>(v.size(), 0) }; 
+	mbc0.q = { {}, q };
+	mbc0.alpha = { {}, v };
+	mbc0.alphaD = { {}, a };
 
-  forwardKinematics(mb, mbc);
-  forwardKinematics(mb, mbc0);
+	forwardKinematics(mb, mbc);
+	forwardKinematics(mb, mbc0);
 
-  //integrating on the whole time step
-  eulerIntegration(mb, mbc0, step);
+	//integrating on the whole time step
+	eulerIntegration(mb, mbc0, step);
 
-  //integrating with constant velocity on small time step
-  const int N = 5000;
-  for (int i = 0; i < N; ++i)
-  {
-    eulerIntegration(mb, mbc, step/N);
-    for (size_t j = 0; j < v.size(); ++j)
-      mbc.alpha[1][j] += a[j] * step / N;
-    forwardKinematics(mb, mbc);
-  }
+	//integrating with constant velocity on small time step
+	const int N = 5000;
+	for (int i = 0; i < N; ++i)
+	{
+		eulerIntegration(mb, mbc, step/N);
+		for (size_t j = 0; j < v.size(); ++j)
+			mbc.alpha[1][j] += a[j] * step / N;
+		forwardKinematics(mb, mbc);
+	}
 
-  for (size_t i=0; i<q.size(); ++i)
-  { 
-    BOOST_CHECK_CLOSE_FRACTION(mbc0.q[1][i], mbc.q[1][i], 1e-3);
-  }
+	for (size_t i=0; i<q.size(); ++i)
+	{ 
+		BOOST_CHECK_CLOSE_FRACTION(mbc0.q[1][i], mbc.q[1][i], 1e-3);
+	}
 }
 
 BOOST_AUTO_TEST_CASE(JointIntegrationTest)
 {
-  const double pi = constants::pi<double>();
-  const double c2 = std::sqrt(2) / 2;
+	const double pi = constants::pi<double>();
+	const double c2 = std::sqrt(2) / 2;
 
-  testConstantSpeedIntegration(Joint::Rev, 1, { 1 }, { 0.5 }, { 1.5 });
-  testConstantSpeedIntegration(Joint::Prism, 1, { 1 }, { 0.5 }, { 1.5 });
-  testConstantSpeedIntegration(Joint::Spherical, 1, { 1, 0, 0, 0 }, { pi / 2, 0, 0 }, { c2, c2, 0, 0 });
-  testConstantSpeedIntegration(Joint::Spherical, 1, { c2, 0, c2, 0 }, { pi / 2, 0, 0 }, { 0.5, 0.5, 0.5, -0.5 });
-  //testConstantSpeedIntegration(Joint::Planar, 1, { 1 }, { 0.5 }, { 1.5 });
-  testConstantSpeedIntegration(Joint::Cylindrical, 1, { 1, 2 }, { 0.5, 0.25 }, { 1.5, 2.25 });
-  testConstantSpeedIntegration(Joint::Free, 1, { 1, 0, 0, 0, 1, 2, 3 }, { pi / 2, 0, 0, 0.5, 0.25, -0.5 }, { c2, c2, 0, 0, 1.5, 2.25, 2.5 });
-  testConstantSpeedIntegration(Joint::Free, 1, { c2, 0, c2, 0, 1, 2, 3 }, { pi / 2, 0, 0, 0.5, 0.25, -0.5 }, { 0.5, 0.5, 0.5, -0.5, 0.5, 2.25, 2.5 });
+	testConstantSpeedIntegration(Joint::Rev, 1, { 1 }, { 0.5 }, { 1.5 });
+	testConstantSpeedIntegration(Joint::Prism, 1, { 1 }, { 0.5 }, { 1.5 });
+	testConstantSpeedIntegration(Joint::Spherical, 1, { 1, 0, 0, 0 }, { pi / 2, 0, 0 }, { c2, c2, 0, 0 });
+	testConstantSpeedIntegration(Joint::Spherical, 1, { c2, 0, c2, 0 }, { pi / 2, 0, 0 }, { 0.5, 0.5, 0.5, -0.5 });
+	//testConstantSpeedIntegration(Joint::Planar, 1, { 1 }, { 0.5 }, { 1.5 });
+	testConstantSpeedIntegration(Joint::Cylindrical, 1, { 1, 2 }, { 0.5, 0.25 }, { 1.5, 2.25 });
+	testConstantSpeedIntegration(Joint::Free, 1, { 1, 0, 0, 0, 1, 2, 3 }, { pi / 2, 0, 0, 0.5, 0.25, -0.5 }, { c2, c2, 0, 0, 1.5, 2.25, 2.5 });
+	testConstantSpeedIntegration(Joint::Free, 1, { c2, 0, c2, 0, 1, 2, 3 }, { pi / 2, 0, 0, 0.5, 0.25, -0.5 }, { 0.5, 0.5, 0.5, -0.5, 0.5, 2.25, 2.5 });
 
-  std::vector<double> q, v, a;
-  std::tie(q, v, a) = randQVA(Joint::Rev);
-  testConstantAccelerationIntegration(Joint::Rev, 1, q, v, a);
-  std::tie(q, v, a) = randQVA(Joint::Prism);
-  testConstantAccelerationIntegration(Joint::Prism, 1, q, v, a);
-  std::tie(q, v, a) = randQVA(Joint::Spherical);
-  testConstantAccelerationIntegration(Joint::Spherical, 0.01, q, v, a);
-  //std::tie(q, v, a) = randQVA(Joint::Planar);
-  //testConstantAccelerationIntegration(Joint::Planar, 1, q, v, a);
-  std::tie(q, v, a) = randQVA(Joint::Cylindrical);
-  testConstantAccelerationIntegration(Joint::Cylindrical, 1, q, v, a);
-  std::tie(q, v, a) = randQVA(Joint::Free);
-  testConstantAccelerationIntegration(Joint::Free, 0.01, q, v, a);
+	std::vector<double> q, v, a;
+	std::tie(q, v, a) = randQVA(Joint::Rev);
+	testConstantAccelerationIntegration(Joint::Rev, 1, q, v, a);
+	std::tie(q, v, a) = randQVA(Joint::Prism);
+	testConstantAccelerationIntegration(Joint::Prism, 1, q, v, a);
+	std::tie(q, v, a) = randQVA(Joint::Spherical);
+	testConstantAccelerationIntegration(Joint::Spherical, 0.01, q, v, a);
+	//std::tie(q, v, a) = randQVA(Joint::Planar);
+	//testConstantAccelerationIntegration(Joint::Planar, 1, q, v, a);
+	std::tie(q, v, a) = randQVA(Joint::Cylindrical);
+	testConstantAccelerationIntegration(Joint::Cylindrical, 1, q, v, a);
+	std::tie(q, v, a) = randQVA(Joint::Free);
+	testConstantAccelerationIntegration(Joint::Free, 0.01, q, v, a);
 }


### PR DESCRIPTION
This PR basically corrects the EulerIntegration scheme.
Previously, it was done like this:
```
x(k+1) = x(k) + v(k)*dt
v(k+1) = v(k) + a(k)*dt
```
or corresponding formulas for more complex joints. (`x` is the joint position, `v` its velocity and `a` its acceleration). This was corresponding to integrate position with constant velocity then velocity with constant acceleration, so that the acceleration `a(k)` at instant `k` was only influencing the position `x(k+2)`.
Now it is done like this:
```
x(k+1) = x(k) + v(k)*dt + 1/2*a(k)*dt^2
v(k+1) = v(k) + a(k)*dt
```
which corresponds to integrating both position and velocity for a constant acceleration.

There are still things to check/correct:
- for planar joints, I kept the old formula, because I don't quite understand (yet) what is done.
- the integration of the translation part of a free joint seems odd: integrating N time a constant velocity with increments dt/N or once with increment dt does not yield the same results. This was already the case in previous version.