### PR TITLE
Option for SIMD compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ option(PYTHON_BINDING_USER_INSTALL "Install the Python bindings in user space" $
 option(PYTHON_BINDING_FORCE_PYTHON3 "Use pip3/python3 instead of pip/python" OFF)
 option(DISABLE_TESTS "Disable unit tests." OFF)
 option(BENCHMARKS "Generate benchmarks." OFF)
+option(ENABLE_SIMD "Build with all SIMD instructions on the current local machine" OFF)
 
 if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-sign-conversion -std=c++0x -pedantic")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,23 @@ set(HEADERS RBDyn/Body.h RBDyn/Joint.h RBDyn/MultiBodyGraph.h RBDyn/MultiBody.h 
   RBDyn/Momentum.h RBDyn/ZMP.h RBDyn/IDIM.h RBDyn/VisServo.h RBDyn/util.hh RBDyn/util.hxx RBDyn/Coriolis.h)
 
 add_library(RBDyn SHARED ${SOURCES} ${HEADERS})
+
+if(ENABLE_SIMD)
+  if(MSVC)
+    target_compile_options(RBDyn PUBLIC /arch:SSE2 /arch:AVX /arch:AVX2)
+  elseif(CMAKE_COMPILER_IS_GNUCXX)
+    execute_process(
+      COMMAND ${CMAKE_CXX_COMPILER} -dumpfullversion -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+    set(CXX_COMPILER_VERSION ${GCC_VERSION})
+    target_compile_options(RBDyn PUBLIC -march=native)
+    if(GCC_VERSION VERSION_GREATER 7.0)
+      target_compile_options(RBDyn PUBLIC -faligned-new)
+    endif()
+  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    target_compile_options(RBDyn PUBLIC -march=native -faligned-new)
+  endif()
+endif()
+
 target_link_libraries(RBDyn SpaceVecAlg::SpaceVecAlg)
 set_target_properties(RBDyn PROPERTIES COMPILE_FLAGS "-Drbdyn_EXPORTS")
 set_target_properties(RBDyn PROPERTIES SOVERSION 0 VERSION 0.9.0)


### PR DESCRIPTION
In some of my projects I am using Eigen compiled with SIMD instructions (`-march=native`) and as such I need your library compiled with the same instructions. This PR adds a CMake option to do so: disabled by default to not break anything.