### PR TITLE
Various improvements

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,6 +14,9 @@ on:
     - "**"
     tags:
     - v*
+  pull_request:
+    branches:
+    - "**"
 jobs:
   check-tag:
     runs-on: ubuntu-18.04

--- a/.github/workflows/sources/package.yml
+++ b/.github/workflows/sources/package.yml
@@ -30,6 +30,9 @@ on:
       - '**'
     tags:
       - v*
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   # For a given tag vX.Y.Z, this checks:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,6 @@ include(cmake/base.cmake)
 include(cmake/cython/cython.cmake)
 include(cmake/msvc-specific.cmake)
 
-# Disable -Werror on Unix for now.
-set(CXX_DISABLE_WERROR True)
-
 project(RBDyn CXX)
 
 option(BENCHMARKS "Generate benchmarks." OFF)

--- a/src/RBDyn/CoM.cpp
+++ b/src/RBDyn/CoM.cpp
@@ -21,7 +21,7 @@ Eigen::Vector3d computeCoM(const MultiBody & mb, const MultiBodyConfig & mbc)
   Vector3d com = Vector3d::Zero();
   double totalMass = 0.;
 
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     double mass = bodies[i].inertia().mass();
 
@@ -43,7 +43,7 @@ Eigen::Vector3d computeCoMVelocity(const MultiBody & mb, const MultiBodyConfig &
   Vector3d comV = Vector3d::Zero();
   double totalMass = 0.;
 
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     double mass = bodies[i].inertia().mass();
     totalMass += mass;
@@ -68,7 +68,7 @@ Eigen::Vector3d computeCoMAcceleration(const MultiBody & mb, const MultiBodyConf
   Vector3d comA = Vector3d::Zero();
   double totalMass = 0.;
 
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     double mass = bodies[i].inertia().mass();
 
@@ -120,15 +120,15 @@ Eigen::Vector3d sComputeCoMAcceleration(const MultiBody & mb, const MultiBodyCon
 CoMJacobianDummy::CoMJacobianDummy() {}
 
 CoMJacobianDummy::CoMJacobianDummy(const MultiBody & mb)
-: jac_(3, mb.nrDof()), jacDot_(3, mb.nrDof()), jacFull_(3, mb.nrDof()), jacVec_(mb.nrBodies()), totalMass_(0.),
-  bodiesWeight_(mb.nrBodies(), 1.)
+: jac_(3, mb.nrDof()), jacDot_(3, mb.nrDof()), jacFull_(3, mb.nrDof()), jacVec_(static_cast<size_t>(mb.nrBodies())),
+  totalMass_(0.), bodiesWeight_(static_cast<size_t>(mb.nrBodies()), 1.)
 {
   init(mb);
 }
 
 CoMJacobianDummy::CoMJacobianDummy(const MultiBody & mb, std::vector<double> weight)
-: jac_(3, mb.nrDof()), jacDot_(3, mb.nrDof()), jacFull_(3, mb.nrDof()), jacVec_(mb.nrBodies()), totalMass_(0.),
-  bodiesWeight_(std::move(weight))
+: jac_(3, mb.nrDof()), jacDot_(3, mb.nrDof()), jacFull_(3, mb.nrDof()), jacVec_(static_cast<size_t>(mb.nrBodies())),
+  totalMass_(0.), bodiesWeight_(std::move(weight))
 {
   init(mb);
 
@@ -150,7 +150,7 @@ const Eigen::MatrixXd & CoMJacobianDummy::jacobian(const MultiBody & mb, const M
 
   jac_.setZero();
 
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     const MatrixXd & jac = jacVec_[i].jacobian(mb, mbc);
     jacVec_[i].fullJacobian(mb, jac.block(3, 0, 3, jac.cols()), jacFull_);
@@ -171,7 +171,7 @@ const Eigen::MatrixXd & CoMJacobianDummy::jacobianDot(const MultiBody & mb, cons
 
   jacDot_.setZero();
 
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     const MatrixXd & jac = jacVec_[i].jacobianDot(mb, mbc);
     jacVec_[i].fullJacobian(mb, jac.block(3, 0, 3, jac.cols()), jacFull_);
@@ -210,7 +210,7 @@ void CoMJacobianDummy::init(const rbd::MultiBody & mb)
     Vector3d comT(0, 0, 0);
     if(bodyMass > 0) comT = mb.body(i).inertia().momentum() / bodyMass;
 
-    jacVec_[i] = Jacobian(mb, mb.body(i).name(), comT);
+    jacVec_[static_cast<size_t>(i)] = Jacobian(mb, mb.body(i).name(), comT);
     totalMass_ += mb.body(i).inertia().mass();
   }
 }
@@ -222,17 +222,19 @@ void CoMJacobianDummy::init(const rbd::MultiBody & mb)
 CoMJacobian::CoMJacobian() {}
 
 CoMJacobian::CoMJacobian(const MultiBody & mb)
-: jac_(3, mb.nrDof()), jacDot_(3, mb.nrDof()), bodiesCoeff_(mb.nrBodies()), bodiesCoM_(mb.nrBodies()),
-  jointsSubBodies_(mb.nrJoints()), bodiesCoMWorld_(mb.nrBodies()), bodiesCoMVelB_(mb.nrBodies()),
-  normalAcc_(mb.nrJoints()), weight_(mb.nrBodies(), 1.)
+: jac_(3, mb.nrDof()), jacDot_(3, mb.nrDof()), bodiesCoeff_(static_cast<size_t>(mb.nrBodies())),
+  bodiesCoM_(static_cast<size_t>(mb.nrBodies())), jointsSubBodies_(static_cast<size_t>(mb.nrJoints())),
+  bodiesCoMWorld_(static_cast<size_t>(mb.nrBodies())), bodiesCoMVelB_(static_cast<size_t>(mb.nrBodies())),
+  normalAcc_(static_cast<size_t>(mb.nrJoints())), weight_(static_cast<size_t>(mb.nrBodies()), 1.)
 {
   init(mb);
 }
 
 CoMJacobian::CoMJacobian(const MultiBody & mb, std::vector<double> weight)
-: jac_(3, mb.nrDof()), jacDot_(3, mb.nrDof()), bodiesCoeff_(mb.nrBodies()), bodiesCoM_(mb.nrBodies()),
-  jointsSubBodies_(mb.nrJoints()), bodiesCoMWorld_(mb.nrBodies()), bodiesCoMVelB_(mb.nrBodies()),
-  normalAcc_(mb.nrJoints()), weight_(std::move(weight))
+: jac_(3, mb.nrDof()), jacDot_(3, mb.nrDof()), bodiesCoeff_(static_cast<size_t>(mb.nrBodies())),
+  bodiesCoM_(static_cast<size_t>(mb.nrBodies())), jointsSubBodies_(static_cast<size_t>(mb.nrJoints())),
+  bodiesCoMWorld_(static_cast<size_t>(mb.nrBodies())), bodiesCoMVelB_(static_cast<size_t>(mb.nrBodies())),
+  normalAcc_(static_cast<size_t>(mb.nrJoints())), weight_(std::move(weight))
 {
   if(int(weight_.size()) != mb.nrBodies())
   {
@@ -256,11 +258,11 @@ void CoMJacobian::updateInertialParameters(const MultiBody & mb)
   for(int i = 0; i < mb.nrBodies(); ++i)
   {
     double bodyMass = mb.body(i).inertia().mass();
-    bodiesCoeff_[i] = (bodyMass * weight_[i]) / mass;
+    bodiesCoeff_[static_cast<size_t>(i)] = (bodyMass * weight_[static_cast<size_t>(i)]) / mass;
     if(bodyMass > 0)
-      bodiesCoM_[i] = sva::PTransformd((mb.body(i).inertia().momentum() / bodyMass).eval());
+      bodiesCoM_[static_cast<size_t>(i)] = sva::PTransformd((mb.body(i).inertia().momentum() / bodyMass).eval());
     else
-      bodiesCoM_[i] = sva::PTransformd::Identity();
+      bodiesCoM_[static_cast<size_t>(i)] = sva::PTransformd::Identity();
   }
 }
 
@@ -282,7 +284,7 @@ const Eigen::MatrixXd & CoMJacobian::jacobian(const MultiBody & mb, const MultiB
   jac_.setZero();
 
   // we pre compute the CoM position of each bodie in world frame
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     // the transformation must be read {}^0E_p {}^pT_N {}^NX_0
     sva::PTransformd X_0_com_w = bodiesCoM_[i] * mbc.bodyPosW[i];
@@ -290,17 +292,18 @@ const Eigen::MatrixXd & CoMJacobian::jacobian(const MultiBody & mb, const MultiB
   }
 
   int curJ = 0;
-  for(int i = 0; i < mb.nrJoints(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrJoints()); ++i)
   {
     std::vector<int> & subBodies = jointsSubBodies_[i];
     sva::PTransformd X_i_0 = mbc.bodyPosW[i].inv();
     for(int b : subBodies)
     {
-      sva::PTransformd X_i_com = bodiesCoMWorld_[b] * X_i_0;
+      const auto body_index = static_cast<size_t>(b);
+      sva::PTransformd X_i_com = bodiesCoMWorld_[body_index] * X_i_0;
       for(int dof = 0; dof < joints[i].dof(); ++dof)
       {
         jac_.col(curJ + dof).noalias() +=
-            (X_i_com.linearMul(sva::MotionVecd(mbc.motionSubspace[i].col(dof)))) * bodiesCoeff_[b];
+            (X_i_com.linearMul(sva::MotionVecd(mbc.motionSubspace[i].col(dof)))) * bodiesCoeff_[body_index];
       }
     }
     curJ += joints[i].dof();
@@ -316,26 +319,27 @@ const Eigen::MatrixXd & CoMJacobian::jacobianDot(const MultiBody & mb, const Mul
   jacDot_.setZero();
 
   // we pre compute the CoM position/velocity of each bodie
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     bodiesCoMWorld_[i] = bodiesCoM_[i] * mbc.bodyPosW[i];
     bodiesCoMVelB_[i] = bodiesCoM_[i] * mbc.bodyVelB[i];
   }
 
   int curJ = 0;
-  for(int i = 0; i < mb.nrJoints(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrJoints()); ++i)
   {
     std::vector<int> & subBodies = jointsSubBodies_[i];
     sva::PTransformd X_i_0 = mbc.bodyPosW[i].inv();
 
     for(int b : subBodies)
     {
-      sva::PTransformd X_i_com = bodiesCoMWorld_[b] * X_i_0;
-      sva::PTransformd E_b_0(Eigen::Matrix3d(mbc.bodyPosW[b].rotation().transpose()));
+      const auto body_index = static_cast<size_t>(b);
+      sva::PTransformd X_i_com = bodiesCoMWorld_[body_index] * X_i_0;
+      sva::PTransformd E_b_0(Eigen::Matrix3d(mbc.bodyPosW[body_index].rotation().transpose()));
 
       // angular velocity of rotation N to O
-      sva::MotionVecd E_Vb(mbc.bodyVelW[b].angular(), Eigen::Vector3d::Zero());
-      sva::MotionVecd X_Vcom_i_com = X_i_com * mbc.bodyVelB[i] - bodiesCoMVelB_[b];
+      sva::MotionVecd E_Vb(mbc.bodyVelW[body_index].angular(), Eigen::Vector3d::Zero());
+      sva::MotionVecd X_Vcom_i_com = X_i_com * mbc.bodyVelB[i] - bodiesCoMVelB_[body_index];
 
       for(int dof = 0; dof < joints[i].dof(); ++dof)
       {
@@ -346,7 +350,7 @@ const Eigen::MatrixXd & CoMJacobian::jacobianDot(const MultiBody & mb, const Mul
         // X_i_com_d = (Vi - Vcom)_com x X_i_com
         jacDot_.col(curJ + dof).noalias() +=
             ((E_Vb.cross(E_b_0 * X_i_com * S_ij)).linear() + (E_b_0 * X_Vcom_i_com.cross(X_i_com * S_ij)).linear())
-            * bodiesCoeff_[b];
+            * bodiesCoeff_[body_index];
       }
     }
     curJ += joints[i].dof();
@@ -358,7 +362,7 @@ const Eigen::MatrixXd & CoMJacobian::jacobianDot(const MultiBody & mb, const Mul
 Eigen::Vector3d CoMJacobian::velocity(const MultiBody & mb, const MultiBodyConfig & mbc) const
 {
   Eigen::Vector3d comV = Eigen::Vector3d::Zero();
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     const Eigen::Vector3d & comT = bodiesCoM_[i].translation();
 
@@ -376,16 +380,19 @@ Eigen::Vector3d CoMJacobian::normalAcceleration(const MultiBody & mb, const Mult
   const std::vector<int> & pred = mb.predecessors();
   const std::vector<int> & succ = mb.successors();
 
-  for(int i = 0; i < mb.nrJoints(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrJoints()); ++i)
   {
     const sva::PTransformd & X_p_i = mbc.parentToSon[i];
     const sva::MotionVecd & vj_i = mbc.jointVelocity[i];
     const sva::MotionVecd & vb_i = mbc.bodyVelB[i];
 
+    const auto pred_index = static_cast<size_t>(pred[i]);
+    const auto succ_index = static_cast<size_t>(succ[i]);
+
     if(pred[i] != -1)
-      normalAcc_[succ[i]] = X_p_i * normalAcc_[pred[i]] + vb_i.cross(vj_i);
+      normalAcc_[succ_index] = X_p_i * normalAcc_[pred_index] + vb_i.cross(vj_i);
     else
-      normalAcc_[succ[i]] = vb_i.cross(vj_i);
+      normalAcc_[succ_index] = vb_i.cross(vj_i);
   }
 
   return normalAcceleration(mb, mbc, normalAcc_);
@@ -396,7 +403,7 @@ Eigen::Vector3d CoMJacobian::normalAcceleration(const MultiBody & mb,
                                                 const std::vector<sva::MotionVecd> & normalAccB) const
 {
   Eigen::Vector3d comA(Eigen::Vector3d::Zero());
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     const Eigen::Vector3d & comT = bodiesCoM_[i].translation();
 
@@ -510,7 +517,7 @@ void CoMJacobian::init(const MultiBody & mb)
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
-    std::vector<int> & subBodies = jointsSubBodies_[i];
+    std::vector<int> & subBodies = jointsSubBodies_[static_cast<size_t>(i)];
     jointBodiesSuccessors(mb, i, subBodies);
   }
 }

--- a/src/RBDyn/EulerIntegration.cpp
+++ b/src/RBDyn/EulerIntegration.cpp
@@ -89,6 +89,7 @@ void eulerJointIntegration(Joint::Type type,
       // don't break, we go in spherical
     }
     /// @todo manage reverse joint
+    /* fallthrough */
     case Joint::Spherical:
     {
       Eigen::Quaterniond qi(q[0], q[1], q[2], q[3]);
@@ -125,7 +126,7 @@ void eulerIntegration(const MultiBody & mb, MultiBodyConfig & mbc, double step)
   for(std::size_t i = 0; i < joints.size(); ++i)
   {
     eulerJointIntegration(joints[i].type(), mbc.alpha[i], mbc.alphaD[i], step, mbc.q[i]);
-    for(int j = 0; j < joints[i].dof(); ++j)
+    for(size_t j = 0; j < static_cast<size_t>(joints[i].dof()); ++j)
     {
       mbc.alpha[i][j] += mbc.alphaD[i][j] * step;
     }

--- a/src/RBDyn/FA.cpp
+++ b/src/RBDyn/FA.cpp
@@ -22,6 +22,9 @@ void forwardAcceleration(const MultiBody & mb, MultiBodyConfig & mbc, const sva:
 
   for(std::size_t i = 0; i < joints.size(); ++i)
   {
+    const auto pred_index = static_cast<size_t>(pred[i]);
+    const auto succ_index = static_cast<size_t>(succ[i]);
+
     const sva::PTransformd & X_p_i = mbc.parentToSon[i];
 
     const sva::MotionVecd & vj_i = mbc.jointVelocity[i];
@@ -30,9 +33,9 @@ void forwardAcceleration(const MultiBody & mb, MultiBodyConfig & mbc, const sva:
     const sva::MotionVecd & vb_i = mbc.bodyVelB[i];
 
     if(pred[i] != -1)
-      mbc.bodyAccB[succ[i]] = X_p_i * mbc.bodyAccB[pred[i]] + ai_tan + vb_i.cross(vj_i);
+      mbc.bodyAccB[succ_index] = X_p_i * mbc.bodyAccB[pred_index] + ai_tan + vb_i.cross(vj_i);
     else
-      mbc.bodyAccB[succ[i]] = X_p_i * A_0 + ai_tan + vb_i.cross(vj_i);
+      mbc.bodyAccB[succ_index] = X_p_i * A_0 + ai_tan + vb_i.cross(vj_i);
   }
 }
 

--- a/src/RBDyn/FK.cpp
+++ b/src/RBDyn/FK.cpp
@@ -23,14 +23,17 @@ void forwardKinematics(const MultiBody & mb, MultiBodyConfig & mbc)
 
   for(std::size_t i = 0; i < joints.size(); ++i)
   {
+    const auto pred_index = static_cast<size_t>(pred[i]);
+    const auto succ_index = static_cast<size_t>(succ[i]);
+
     mbc.jointConfig[i] = joints[i].pose(mbc.q[i]);
     mbc.parentToSon[i] = mbc.jointConfig[i] * Xt[i];
     mbc.motionSubspace[i] = joints[i].motionSubspace();
 
     if(pred[i] != -1)
-      mbc.bodyPosW[succ[i]] = mbc.parentToSon[i] * mbc.bodyPosW[pred[i]];
+      mbc.bodyPosW[succ_index] = mbc.parentToSon[i] * mbc.bodyPosW[pred_index];
     else
-      mbc.bodyPosW[succ[i]] = mbc.parentToSon[i];
+      mbc.bodyPosW[succ_index] = mbc.parentToSon[i];
   }
 }
 

--- a/src/RBDyn/FV.cpp
+++ b/src/RBDyn/FV.cpp
@@ -16,23 +16,27 @@ namespace rbd
 
 void forwardVelocity(const MultiBody & mb, MultiBodyConfig & mbc)
 {
+
   const std::vector<Joint> & joints = mb.joints();
   const std::vector<int> & pred = mb.predecessors();
   const std::vector<int> & succ = mb.successors();
 
   for(std::size_t i = 0; i < joints.size(); ++i)
   {
+    const auto pred_index = static_cast<size_t>(pred[i]);
+    const auto succ_index = static_cast<size_t>(succ[i]);
+
     const sva::PTransformd & X_p_i = mbc.parentToSon[i];
 
     mbc.jointVelocity[i] = joints[i].motion(mbc.alpha[i]);
 
     if(pred[i] != -1)
-      mbc.bodyVelB[succ[i]] = X_p_i * mbc.bodyVelB[pred[i]] + mbc.jointVelocity[i];
+      mbc.bodyVelB[succ_index] = X_p_i * mbc.bodyVelB[pred_index] + mbc.jointVelocity[i];
     else
-      mbc.bodyVelB[succ[i]] = mbc.jointVelocity[i];
+      mbc.bodyVelB[succ_index] = mbc.jointVelocity[i];
 
-    sva::PTransformd E_0_i(mbc.bodyPosW[succ[i]].rotation());
-    mbc.bodyVelW[succ[i]] = E_0_i.invMul(mbc.bodyVelB[succ[i]]);
+    sva::PTransformd E_0_i(mbc.bodyPosW[succ_index].rotation());
+    mbc.bodyVelW[succ_index] = E_0_i.invMul(mbc.bodyVelB[succ_index]);
   }
 }
 

--- a/src/RBDyn/FV.cpp
+++ b/src/RBDyn/FV.cpp
@@ -22,17 +22,20 @@ void forwardVelocity(const MultiBody & mb, MultiBodyConfig & mbc)
 
   for(std::size_t i = 0; i < joints.size(); ++i)
   {
+    const auto pred_index = static_cast<size_t>(pred[i]);
+    const auto succ_index = static_cast<size_t>(succ[i]);
+
     const sva::PTransformd & X_p_i = mbc.parentToSon[i];
 
     mbc.jointVelocity[i] = joints[i].motion(mbc.alpha[i]);
 
     if(pred[i] != -1)
-      mbc.bodyVelB[succ[i]] = X_p_i * mbc.bodyVelB[pred[i]] + mbc.jointVelocity[i];
+      mbc.bodyVelB[succ_index] = X_p_i * mbc.bodyVelB[pred_index] + mbc.jointVelocity[i];
     else
-      mbc.bodyVelB[succ[i]] = mbc.jointVelocity[i];
+      mbc.bodyVelB[succ_index] = mbc.jointVelocity[i];
 
-    sva::PTransformd E_0_i(mbc.bodyPosW[succ[i]].rotation());
-    mbc.bodyVelW[succ[i]] = E_0_i.invMul(mbc.bodyVelB[succ[i]]);
+    sva::PTransformd E_0_i(mbc.bodyPosW[succ_index].rotation());
+    mbc.bodyVelW[succ_index] = E_0_i.invMul(mbc.bodyVelB[succ_index]);
   }
 }
 

--- a/src/RBDyn/FV.cpp
+++ b/src/RBDyn/FV.cpp
@@ -16,27 +16,23 @@ namespace rbd
 
 void forwardVelocity(const MultiBody & mb, MultiBodyConfig & mbc)
 {
-
   const std::vector<Joint> & joints = mb.joints();
   const std::vector<int> & pred = mb.predecessors();
   const std::vector<int> & succ = mb.successors();
 
   for(std::size_t i = 0; i < joints.size(); ++i)
   {
-    const auto pred_index = static_cast<size_t>(pred[i]);
-    const auto succ_index = static_cast<size_t>(succ[i]);
-
     const sva::PTransformd & X_p_i = mbc.parentToSon[i];
 
     mbc.jointVelocity[i] = joints[i].motion(mbc.alpha[i]);
 
     if(pred[i] != -1)
-      mbc.bodyVelB[succ_index] = X_p_i * mbc.bodyVelB[pred_index] + mbc.jointVelocity[i];
+      mbc.bodyVelB[succ[i]] = X_p_i * mbc.bodyVelB[pred[i]] + mbc.jointVelocity[i];
     else
-      mbc.bodyVelB[succ_index] = mbc.jointVelocity[i];
+      mbc.bodyVelB[succ[i]] = mbc.jointVelocity[i];
 
-    sva::PTransformd E_0_i(mbc.bodyPosW[succ_index].rotation());
-    mbc.bodyVelW[succ_index] = E_0_i.invMul(mbc.bodyVelB[succ_index]);
+    sva::PTransformd E_0_i(mbc.bodyPosW[succ[i]].rotation());
+    mbc.bodyVelW[succ[i]] = E_0_i.invMul(mbc.bodyVelB[succ[i]]);
   }
 }
 

--- a/src/RBDyn/ID.cpp
+++ b/src/RBDyn/ID.cpp
@@ -13,7 +13,7 @@
 namespace rbd
 {
 
-InverseDynamics::InverseDynamics(const MultiBody & mb) : f_(mb.nrBodies()) {}
+InverseDynamics::InverseDynamics(const MultiBody & mb) : f_(static_cast<size_t>(mb.nrBodies())) {}
 
 void InverseDynamics::inverseDynamics(const MultiBody & mb, MultiBodyConfig & mbc)
 {
@@ -33,7 +33,7 @@ void InverseDynamics::inverseDynamics(const MultiBody & mb, MultiBodyConfig & mb
     const sva::MotionVecd & vb_i = mbc.bodyVelB[i];
 
     if(pred[i] != -1)
-      mbc.bodyAccB[i] = X_p_i * mbc.bodyAccB[pred[i]] + ai_tan + vb_i.cross(vj_i);
+      mbc.bodyAccB[i] = X_p_i * mbc.bodyAccB[static_cast<size_t>(pred[i])] + ai_tan + vb_i.cross(vj_i);
     else
       mbc.bodyAccB[i] = X_p_i * a_0 + ai_tan + vb_i.cross(vj_i);
 
@@ -46,7 +46,7 @@ void InverseDynamics::inverseDynamics(const MultiBody & mb, MultiBodyConfig & mb
 
 void InverseDynamics::inverseDynamicsNoInertia(const MultiBody & mb, MultiBodyConfig & mbc)
 {
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     f_[i] = mbc.bodyPosW[i].dualMul(mbc.force[i]);
   }
@@ -105,15 +105,17 @@ void InverseDynamics::computeJointTorques(const MultiBody & mb, MultiBodyConfig 
 
   for(int i = static_cast<int>(bodies.size()) - 1; i >= 0; --i)
   {
-    for(int j = 0; j < joints[i].dof(); ++j)
+    const auto ui = static_cast<size_t>(i);
+    for(int j = 0; j < joints[ui].dof(); ++j)
     {
-      mbc.jointTorque[i][j] = mbc.motionSubspace[i].col(j).transpose() * f_[i].vector();
+      const auto uj = static_cast<size_t>(j);
+      mbc.jointTorque[ui][uj] = mbc.motionSubspace[ui].col(j).transpose() * f_[ui].vector();
     }
 
-    if(pred[i] != -1)
+    if(pred[ui] != -1)
     {
-      const sva::PTransformd & X_p_i = mbc.parentToSon[i];
-      f_[pred[i]] = f_[pred[i]] + X_p_i.transMul(f_[i]);
+      const sva::PTransformd & X_p_i = mbc.parentToSon[ui];
+      f_[static_cast<size_t>(pred[ui])] = f_[static_cast<size_t>(pred[ui])] + X_p_i.transMul(f_[ui]);
     }
   }
 }

--- a/src/RBDyn/IK.cpp
+++ b/src/RBDyn/IK.cpp
@@ -57,15 +57,15 @@ bool InverseKinematics::inverseKinematics(const MultiBody & mb,
     // non-strict zeros in jacobian can be a problem...
     jacMat = jacMat.unaryExpr(CwiseRoundOp(-almost_zero_, almost_zero_));
     svd_.compute(jacMat, Eigen::ComputeThinU | Eigen::ComputeThinV);
-    rotErr = sva::rotationError(mbc.bodyPosW[ef_index_].rotation(), ef_target.rotation());
-    v << rotErr, ef_target.translation() - mbc.bodyPosW[ef_index_].translation();
+    rotErr = sva::rotationError(mbc.bodyPosW[static_cast<size_t>(ef_index_)].rotation(), ef_target.rotation());
+    v << rotErr, ef_target.translation() - mbc.bodyPosW[static_cast<size_t>(ef_index_)].translation();
     converged = v.norm() < threshold_;
     res = svd_.solve(v);
 
     dof = 0;
     for(auto index : jac_.jointsPath())
     {
-      std::vector<double> & qi = mbc.q[index];
+      std::vector<double> & qi = mbc.q[static_cast<size_t>(index)];
       for(auto & qv : qi)
       {
         qv += lambda_ * res[dof];

--- a/src/RBDyn/Jacobian.cpp
+++ b/src/RBDyn/Jacobian.cpp
@@ -104,21 +104,21 @@ MultiBody Jacobian::subMultiBody(const MultiBody & mb) const
     succ.push_back(index);
     pred.push_back(index - 1);
 
-    if (index == 0 )
+    if(index == 0)
     {
-      if (reverseJoints_[index])
+      if(reverseJoints_[index])
         Xt.push_back(sva::PTransformd(Eigen::Vector3d(0., 0., 0.)));
       else
         Xt.push_back(mb.transform(i));
     }
     else
     {
-      if (reverseJoints_[index-1])
+      if(reverseJoints_[index - 1])
       {
-        if (reverseJoints_[index])
-          Xt.push_back(mb.transform(jointsPath_[index-1]).inv());
+        if(reverseJoints_[index])
+          Xt.push_back(mb.transform(jointsPath_[index - 1]).inv());
         else
-          Xt.push_back(mb.transform(jointsPath_[index-1]).inv()*mb.transform(jointsPath_[index]));
+          Xt.push_back(mb.transform(jointsPath_[index - 1]).inv() * mb.transform(jointsPath_[index]));
       }
       else
       {
@@ -126,7 +126,7 @@ MultiBody Jacobian::subMultiBody(const MultiBody & mb) const
       }
     }
     auto joint = mb.joint(i);
-    if (reverseJoints_[index])
+    if(reverseJoints_[index])
     {
       auto fwd = joint.forward() ? false : true;
       joint.forward(fwd);

--- a/src/RBDyn/Jacobian.cpp
+++ b/src/RBDyn/Jacobian.cpp
@@ -93,7 +93,8 @@ MultiBody Jacobian::subMultiBody(const MultiBody & mb) const
 
   for(int index = 0; index < static_cast<int>(jointsPath_.size()); ++index)
   {
-    int i = jointsPath_[index];
+    const auto uindex = static_cast<size_t>(index);
+    int i = jointsPath_[uindex];
 
     // body info
     bodies.push_back(mb.body(i));
@@ -105,19 +106,19 @@ MultiBody Jacobian::subMultiBody(const MultiBody & mb) const
 
     if(index == 0)
     {
-      if(jointsSign_[index] == -1)
+      if(jointsSign_[uindex] == -1)
         Xt.push_back(sva::PTransformd(Eigen::Vector3d(0., 0., 0.)));
       else
         Xt.push_back(mb.transform(i));
     }
     else
     {
-      if(jointsSign_[index - 1] == -1)
+      if(jointsSign_[uindex - 1] == -1)
       {
-        if(jointsSign_[index] == -1)
-          Xt.push_back(mb.transform(jointsPath_[index - 1]).inv());
+        if(jointsSign_[uindex] == -1)
+          Xt.push_back(mb.transform(jointsPath_[uindex - 1]).inv());
         else
-          Xt.push_back(mb.transform(jointsPath_[index - 1]).inv() * mb.transform(jointsPath_[index]));
+          Xt.push_back(mb.transform(jointsPath_[uindex - 1]).inv() * mb.transform(jointsPath_[uindex]));
       }
       else
       {
@@ -125,7 +126,7 @@ MultiBody Jacobian::subMultiBody(const MultiBody & mb) const
       }
     }
     auto joint = mb.joint(i);
-    if(jointsSign_[index] == -1)
+    if(jointsSign_[uindex] == -1)
     {
       auto fwd = joint.forward() ? false : true;
       joint.forward(fwd);
@@ -179,8 +180,10 @@ const Eigen::MatrixXd & Jacobian::jacobian(const MultiBody & mb,
   if(refBodyIndex_ > 0)
   {
     auto dof_count = jac_.cols();
-    jac_.block(0, 0, 3, dof_count) = mbc.bodyPosW[refBodyIndex_].rotation() * jac_.block(0, 0, 3, dof_count);
-    jac_.block(3, 0, 3, dof_count) = mbc.bodyPosW[refBodyIndex_].rotation() * jac_.block(3, 0, 3, dof_count);
+    jac_.block(0, 0, 3, dof_count) =
+        mbc.bodyPosW[static_cast<size_t>(refBodyIndex_)].rotation() * jac_.block(0, 0, 3, dof_count);
+    jac_.block(3, 0, 3, dof_count) =
+        mbc.bodyPosW[static_cast<size_t>(refBodyIndex_)].rotation() * jac_.block(3, 0, 3, dof_count);
   }
   return jac_;
 }
@@ -196,8 +199,10 @@ const Eigen::MatrixXd & Jacobian::jacobian(const MultiBody & mb, const MultiBody
   if(refBodyIndex_ > 0)
   {
     auto dof_count = jac_.cols();
-    jac_.block(0, 0, 3, dof_count) = mbc.bodyPosW[refBodyIndex_].rotation() * jac_.block(0, 0, 3, dof_count);
-    jac_.block(3, 0, 3, dof_count) = mbc.bodyPosW[refBodyIndex_].rotation() * jac_.block(3, 0, 3, dof_count);
+    jac_.block(0, 0, 3, dof_count) =
+        mbc.bodyPosW[static_cast<size_t>(refBodyIndex_)].rotation() * jac_.block(0, 0, 3, dof_count);
+    jac_.block(3, 0, 3, dof_count) =
+        mbc.bodyPosW[static_cast<size_t>(refBodyIndex_)].rotation() * jac_.block(3, 0, 3, dof_count);
   }
   return jac_;
 }

--- a/src/RBDyn/Jacobian.cpp
+++ b/src/RBDyn/Jacobian.cpp
@@ -159,9 +159,8 @@ static inline const Eigen::MatrixXd & jacobian_(const MultiBody & mb,
   if(ref_index > 0)
   {
     auto dof_count = jac.cols();
-    const auto joint_index = static_cast<size_t>(jointsPath[0]);
-    jac.block(0, 0, 3, dof_count) = mbc.bodyPosW[joint_index].rotation() * jac.block(0, 0, 3, dof_count);
-    jac.block(3, 0, 3, dof_count) = mbc.bodyPosW[joint_index].rotation() * jac.block(3, 0, 3, dof_count);
+    jac.block(0, 0, 3, dof_count) = mbc.bodyPosW[ref_index].rotation() * jac.block(0, 0, 3, dof_count);
+    jac.block(3, 0, 3, dof_count) = mbc.bodyPosW[ref_index].rotation() * jac.block(3, 0, 3, dof_count);
   }
 
   return jac;

--- a/src/RBDyn/MultiBody.cpp
+++ b/src/RBDyn/MultiBody.cpp
@@ -27,14 +27,16 @@ MultiBody::MultiBody(std::vector<Body> bodies,
 {
   for(int i = 0; i < static_cast<int>(bodies_.size()); ++i)
   {
-    bodyNameToInd_[bodies_[i].name()] = i;
-    jointNameToInd_[joints_[i].name()] = i;
+    const auto ui = static_cast<size_t>(i);
 
-    jointPosInParam_[i] = nrParams_;
-    jointPosInDof_[i] = nrDof_;
+    bodyNameToInd_[bodies_[ui].name()] = i;
+    jointNameToInd_[joints_[ui].name()] = i;
 
-    nrParams_ += joints_[i].params();
-    nrDof_ += joints_[i].dof();
+    jointPosInParam_[ui] = nrParams_;
+    jointPosInDof_[ui] = nrDof_;
+
+    nrParams_ += joints_[ui].params();
+    nrDof_ += joints_[ui].dof();
   }
 }
 

--- a/src/RBDyn/MultiBodyConfig.cpp
+++ b/src/RBDyn/MultiBodyConfig.cpp
@@ -419,7 +419,7 @@ void checkMatchMotionSubspace(const MultiBody & mb, const MultiBodyConfig & mbc)
   for(int i = 0; i < static_cast<int>(mbc.motionSubspace.size()); ++i)
   {
     const auto ui = static_cast<size_t>(i);
-    if(mbc.motionSubspace[ui].cols() != static_cast<unsigned>(mb.joint(i).dof()))
+    if(mbc.motionSubspace[ui].cols() != mb.joint(i).dof())
     {
       std::ostringstream str;
       str << "Bad motionSubspace matrix size for Joint " << mb.joint(i) << " at position " << i

--- a/src/RBDyn/MultiBodyGraph.cpp
+++ b/src/RBDyn/MultiBodyGraph.cpp
@@ -268,7 +268,7 @@ std::map<std::string, sva::PTransformd> MultiBodyGraph::bodiesBaseTransform(cons
 
   std::shared_ptr<Node> rootNode = bodyNameToNode_.at(rootBodyName);
   computeTransform(rootNode, nullptr, X_b0_j0);
-  return std::move(X_nb_b);
+  return X_nb_b;
 }
 
 std::map<std::string, std::vector<std::string>> MultiBodyGraph::successorJoints(const std::string & rootBodyName)
@@ -291,7 +291,7 @@ std::map<std::string, std::vector<std::string>> MultiBodyGraph::successorJoints(
 
   std::shared_ptr<Node> rootNode = bodyNameToNode_.at(rootBodyName);
   computeSuccesors(rootNode, nullptr);
-  return std::move(successorJoints);
+  return successorJoints;
 }
 
 std::map<std::string, std::string> MultiBodyGraph::predecessorJoint(const std::string & rootBodyName)
@@ -317,7 +317,7 @@ std::map<std::string, std::string> MultiBodyGraph::predecessorJoint(const std::s
 
   std::shared_ptr<Node> rootNode = bodyNameToNode_.at(rootBodyName);
   computePredecessor(rootNode, nullptr, rootJointName_);
-  return std::move(predJoint);
+  return predJoint;
 }
 
 MultiBodyGraph MultiBodyGraph::fixJoints(const MultiBodyGraph & other,

--- a/src/RBDyn/RBDyn/Body.h
+++ b/src/RBDyn/RBDyn/Body.h
@@ -26,7 +26,7 @@ public:
    * @param rbInertia Body spatial rigid body inertia.
    * @param name Body name, must be unique in a multibody.
    */
-  Body(const sva::RBInertiad & rbInertia, std::string name) : inertia_(rbInertia), name_(name) {}
+  Body(const sva::RBInertiad & rbInertia, std::string name) : inertia_(rbInertia), name_(std::move(name)) {}
 
   /**
    * @param mass Body mass.
@@ -35,7 +35,7 @@ public:
    * @param name Body name, must be unique in a multibody.
    */
   Body(double mass, const Eigen::Vector3d & com, const Eigen::Matrix3d & inertia, std::string name)
-  : inertia_(mass, mass * com, inertia), name_(name)
+  : inertia_(mass, mass * com, inertia), name_(std::move(name))
   {
   }
 

--- a/src/RBDyn/RBDyn/Jacobian.h
+++ b/src/RBDyn/RBDyn/Jacobian.h
@@ -50,6 +50,19 @@ public:
   Jacobian(const MultiBody & mb, const std::string & bodyName, const Eigen::Vector3d & point = Eigen::Vector3d::Zero());
 
   /**
+   * Create a jacobian from a reference body to the specified body.
+   * @param mb Multibody where bodyId is in.
+   * @param bodyName Specified body.
+   * @param refBodyName Reference body.
+   * @param point Point in the body exprimed in body coordinate.
+   * @throw std::out_of_range If bodyId don't exist.
+   */
+  Jacobian(const MultiBody & mb,
+           const std::string & bodyName,
+           const std::string & refBodyName,
+           const Eigen::Vector3d & point = Eigen::Vector3d::Zero());
+
+  /**
    * Compute the jacobian at the point/frame specified by X_0_p.
    * @param mb MultiBody used has model.
    * @param mbc Use bodyPosW and motionSubspace.
@@ -307,6 +320,9 @@ public:
     return jointsPath_;
   }
 
+  /// @return The dof path vector from the root to the specified body.
+  std::vector<int> dofPath(const MultiBody & mb) const;
+
   /// @return The number of degree of freedom in the joint path
   int dof() const
   {
@@ -452,10 +468,14 @@ private:
 
 private:
   std::vector<int> jointsPath_;
+  std::vector<bool> reverseJoints_;
   sva::PTransformd point_;
 
   Eigen::MatrixXd jac_;
   Eigen::MatrixXd jacDot_;
+
+  int body_index_;
+  int ref_index_;
 };
 
 } // namespace rbd

--- a/src/RBDyn/RBDyn/Jacobian.h
+++ b/src/RBDyn/RBDyn/Jacobian.h
@@ -468,7 +468,7 @@ private:
 
 private:
   std::vector<int> jointsPath_;
-  std::vector<bool> reverseJoints_;
+  std::vector<uint8_t> reverseJoints_;
   sva::PTransformd point_;
 
   Eigen::MatrixXd jac_;

--- a/src/RBDyn/RBDyn/Jacobian.h
+++ b/src/RBDyn/RBDyn/Jacobian.h
@@ -42,20 +42,20 @@ public:
 
   /**
    * Create a jacobian from the root body to the specified body.
-   * @param mb Multibody where bodyId is in.
+   * @param mb Multibody where bodyName is in.
    * @param bodyName Specified body.
-   * @param point Point in the body exprimed in body coordinate.
-   * @throw std::out_of_range If bodyId don't exist.
+   * @param point Point in the body expressed in body coordinate.
+   * @throw std::out_of_range If bodyName don't exist.
    */
   Jacobian(const MultiBody & mb, const std::string & bodyName, const Eigen::Vector3d & point = Eigen::Vector3d::Zero());
 
   /**
    * Create a jacobian from a reference body to the specified body.
-   * @param mb Multibody where bodyId is in.
+   * @param mb Multibody where bodyName is in.
    * @param bodyName Specified body.
    * @param refBodyName Reference body.
-   * @param point Point in the body exprimed in body coordinate.
-   * @throw std::out_of_range If bodyId don't exist.
+   * @param point Point in the body expressed in body coordinate.
+   * @throw std::out_of_range If bodyName don't exist.
    */
   Jacobian(const MultiBody & mb,
            const std::string & bodyName,

--- a/src/RBDyn/RBDyn/Jacobian.h
+++ b/src/RBDyn/RBDyn/Jacobian.h
@@ -465,7 +465,7 @@ private:
 
 private:
   std::vector<int> jointsPath_;
-  std::vector<uint8_t> reverseJoints_;
+  std::vector<double> jointsSign_;
   sva::PTransformd point_;
 
   Eigen::MatrixXd jac_;

--- a/src/RBDyn/RBDyn/Jacobian.h
+++ b/src/RBDyn/RBDyn/Jacobian.h
@@ -320,9 +320,6 @@ public:
     return jointsPath_;
   }
 
-  /// @return The dof path vector from the root to the specified body.
-  std::vector<int> dofPath(const MultiBody & mb) const;
-
   /// @return The number of degree of freedom in the joint path
   int dof() const
   {
@@ -474,8 +471,8 @@ private:
   Eigen::MatrixXd jac_;
   Eigen::MatrixXd jacDot_;
 
-  int body_index_;
-  int ref_index_;
+  int bodyIndex_;
+  int refBodyIndex_;
 };
 
 } // namespace rbd

--- a/src/RBDyn/RBDyn/MultiBody.h
+++ b/src/RBDyn/RBDyn/MultiBody.h
@@ -82,14 +82,6 @@ public:
     bodies_[static_cast<std::size_t>(num)] = b;
   }
 
-  /// @return Index of the root body
-  int rootBodyIndex() const
-  {
-    int index = bodyIndexByName(bodies_[0].name());
-    while(parent(index) != -1) index = parent(index);
-    return index;
-  }
-
   /// @return Joints of the multibody system.
   const std::vector<Joint> & joints() const
   {

--- a/src/RBDyn/RBDyn/MultiBody.h
+++ b/src/RBDyn/RBDyn/MultiBody.h
@@ -73,13 +73,13 @@ public:
   /// @return Body at num position in bodies list.
   const Body & body(int num) const
   {
-    return bodies_[num];
+    return bodies_[static_cast<std::size_t>(num)];
   }
 
   /// Set the body num in bodies list.
   void body(int num, const Body & b)
   {
-    bodies_[num] = b;
+    bodies_[static_cast<std::size_t>(num)] = b;
   }
 
   /// @return Index of the root body
@@ -99,7 +99,7 @@ public:
   /// @return Joint at num position in joint list.
   const Joint & joint(int num) const
   {
-    return joints_[num];
+    return joints_[static_cast<std::size_t>(num)];
   }
 
   /// @return Predeccesor body index of each joint.
@@ -111,7 +111,7 @@ public:
   /// @return Predecessor body of joint num.
   int predecessor(int num) const
   {
-    return pred_[num];
+    return pred_[static_cast<std::size_t>(num)];
   }
 
   /// @return Successor body index of each joint.
@@ -123,7 +123,7 @@ public:
   /// @return Successor body of joint num.
   int successor(int num) const
   {
-    return succ_[num];
+    return succ_[static_cast<std::size_t>(num)];
   }
 
   /// @return Parent body index of each body.
@@ -135,7 +135,7 @@ public:
   /// @return Parent body of body num.
   int parent(int num) const
   {
-    return parent_[num];
+    return parent_[static_cast<std::size_t>(num)];
   }
 
   /// @return Transformation from the body base to joint i
@@ -153,13 +153,13 @@ public:
   /// @return Transformation from the body base to joint num
   const sva::PTransformd & transform(int num) const
   {
-    return Xt_[num];
+    return Xt_[static_cast<std::size_t>(num)];
   }
 
   /// Set the transformation from the body base to joint num
   void transform(int num, const sva::PTransformd & Xt)
   {
-    Xt_[num] = Xt;
+    Xt_[static_cast<std::size_t>(num)] = Xt;
   }
 
   /// @return Index of the body with name 'name'.
@@ -189,13 +189,13 @@ public:
   /// @return the joint i position in parameter vector (q).
   int jointPosInParam(int i) const
   {
-    return jointPosInParam_[i];
+    return jointPosInParam_[static_cast<std::size_t>(i)];
   }
 
   /// @return the joint i position in dof vector (alpha, alphaD…).
   int jointPosInDof(int i) const
   {
-    return jointPosInDof_[i];
+    return jointPosInDof_[static_cast<std::size_t>(i)];
   }
 
   /// @return the joint position in parameter vector (q).
@@ -243,7 +243,7 @@ public:
    */
   const Body & sBody(int num) const
   {
-    return bodies_.at(num);
+    return bodies_.at(static_cast<std::size_t>(num));
   }
 
   /** Safe version of @see body.
@@ -251,7 +251,7 @@ public:
    */
   void sBody(int num, const Body & b)
   {
-    bodies_.at(num) = b;
+    bodies_.at(static_cast<std::size_t>(num)) = b;
   }
 
   /** Safe version of @see joint.
@@ -259,7 +259,7 @@ public:
    */
   const Joint & sJoint(int num) const
   {
-    return joints_.at(num);
+    return joints_.at(static_cast<std::size_t>(num));
   }
 
   /** Safe version of @see predecessor.
@@ -267,7 +267,7 @@ public:
    */
   int sPredecessor(int num) const
   {
-    return pred_.at(num);
+    return pred_.at(static_cast<std::size_t>(num));
   }
 
   /** Safe version of @see successor.
@@ -275,7 +275,7 @@ public:
    */
   int sSuccessor(int num) const
   {
-    return succ_.at(num);
+    return succ_.at(static_cast<std::size_t>(num));
   }
 
   /** Safe version of @see parent.
@@ -283,7 +283,7 @@ public:
    */
   int sParent(int num) const
   {
-    return parent_.at(num);
+    return parent_.at(static_cast<std::size_t>(num));
   }
 
   /** Safe version of @see transforms.
@@ -305,7 +305,7 @@ public:
    */
   const sva::PTransformd & sTransform(int num) const
   {
-    return Xt_.at(num);
+    return Xt_.at(static_cast<std::size_t>(num));
   }
 
   /** Safe version of @see transform.
@@ -313,7 +313,7 @@ public:
    */
   void sTransform(int num, const sva::PTransformd & Xt)
   {
-    Xt_.at(num) = Xt;
+    Xt_.at(static_cast<std::size_t>(num)) = Xt;
   }
 
   /** Safe version of @see jointPosInParam.
@@ -321,7 +321,7 @@ public:
    */
   int sJointPosInParam(int i) const
   {
-    return jointPosInParam_.at(i);
+    return jointPosInParam_.at(static_cast<std::size_t>(i));
   }
 
   /** Safe version of @see jointPosInDof.
@@ -329,7 +329,7 @@ public:
    */
   int sJointPosInDof(int i) const
   {
-    return jointPosInDof_.at(i);
+    return jointPosInDof_.at(static_cast<std::size_t>(i));
   }
 
   /** Safe version of @see bodyIndexByName.

--- a/src/RBDyn/RBDyn/MultiBody.h
+++ b/src/RBDyn/RBDyn/MultiBody.h
@@ -82,6 +82,14 @@ public:
     bodies_[num] = b;
   }
 
+  /// @return Index of the root body
+  int rootBodyIndex() const
+  {
+    int index = bodyIndexByName(bodies_[0].name());
+    while(parent(index) != -1) index = parent(index);
+    return index;
+  }
+
   /// @return Joints of the multibody system.
   const std::vector<Joint> & joints() const
   {

--- a/src/RBDyn/RBDyn/MultiBodyConfig.h
+++ b/src/RBDyn/RBDyn/MultiBodyConfig.h
@@ -274,7 +274,7 @@ inline void ConfigConverter::convertJoint(const std::vector<T> & from, std::vect
 {
   for(std::size_t i = 0; i < jInd_.size(); ++i)
   {
-    to[jInd_[i]] = from[i + 1];
+    to[static_cast<size_t>(jInd_[i])] = from[i + 1];
   }
 }
 
@@ -295,10 +295,10 @@ inline std::vector<T> ConfigConverter::convertJoint(const std::vector<T> & from)
   std::vector<T> to(from.size());
   for(std::size_t i = 0; i < jInd_.size(); ++i)
   {
-    to[jInd_[i]] = from[i + 1];
+    to[static_cast<size_t>(jInd_[i])] = from[i + 1];
   }
 
-  return std::move(to);
+  return to;
 }
 
 } // namespace rbd

--- a/src/RBDyn/RBDyn/VisServo.h
+++ b/src/RBDyn/RBDyn/VisServo.h
@@ -54,9 +54,7 @@ RBDYN_DLLAPI void imagePointJacobianDot(const Eigen::Vector2d & imagePoint,
  * @param rot_angle_threshold is the minimum angle of an axis angle representation where the angle
  *		is considered as zero
  */
-RBDYN_DLLAPI void poseJacobian(const Eigen::Matrix3d & rotation,
-                               Eigen::Matrix<double, 6, 6> & jac,
-                               const double rot_angle_threshold = 1.0e-8);
+RBDYN_DLLAPI void poseJacobian(const Eigen::Matrix3d & rotation, Eigen::Matrix<double, 6, 6> & jac);
 
 /**
  * Compute the interaction matrix of the depth derivative

--- a/src/RBDyn/VisServo.cpp
+++ b/src/RBDyn/VisServo.cpp
@@ -39,7 +39,7 @@ void imagePointJacobianDot(const Eigen::Vector2d & imagePoint,
       depthDot / Z_sq, (imagePointSpeed(1) * depth - imagePoint(1) * depthDot) / Z_sq;
 }
 
-void poseJacobian(const Eigen::Matrix3d & rotation, Eigen::Matrix<double, 6, 6> & jac, const double rot_angle_threshold)
+void poseJacobian(const Eigen::Matrix3d & rotation, Eigen::Matrix<double, 6, 6> & jac)
 {
   Eigen::Matrix3d i3 = Eigen::Matrix3d::Identity();
 

--- a/src/parsers/RBDyn/parsers/common.h
+++ b/src/parsers/RBDyn/parsers/common.h
@@ -23,7 +23,7 @@ namespace rbd
 namespace parsers
 {
 
-enum class RBDYN_PARSERS_DLLAPI ParserInput
+enum class ParserInput
 {
   File,
   Description

--- a/src/parsers/yaml.cpp
+++ b/src/parsers/yaml.cpp
@@ -162,10 +162,7 @@ void RBDynFromYAML::parseFrame(const YAML::Node & frame,
       {
         throw std::runtime_error("YAML: Invalid array size (" + name + "->intertial->frame->xyz");
       }
-      for(size_t i = 0; i < 3; ++i)
-      {
-        xyz[i] = xyz_data[i];
-      }
+      std::copy_n(std::begin(xyz_data), 3, xyz.data());
     }
     auto rpy_node = frame["rpy"];
     if(rpy_node)
@@ -175,10 +172,7 @@ void RBDynFromYAML::parseFrame(const YAML::Node & frame,
       {
         throw std::runtime_error("YAML: Invalid array size (" + name + "->intertial->frame->rpy");
       }
-      for(size_t i = 0; i < 3; ++i)
-      {
-        rpy[i] = rpy_data[i];
-      }
+      std::copy_n(std::begin(rpy_data), 3, rpy.data());
       if(frame["anglesInDegrees"].as<bool>(angles_in_degrees_))
       {
         rpy *= M_PI / 180.;
@@ -492,10 +486,7 @@ void RBDynFromYAML::parseJointAxis(const YAML::Node & axis, const std::string & 
     {
       throw std::runtime_error("YAML: Invalid array size (" + name + "->intertial->frame->axis");
     }
-    for(size_t i = 0; i < 3; ++i)
-    {
-      joint_axis[i] = axis_data[i];
-    }
+    std::copy_n(std::begin(axis_data), 3, joint_axis.data());
   }
   else
   {

--- a/tests/AlgoTest.cpp
+++ b/tests/AlgoTest.cpp
@@ -402,15 +402,19 @@ double testEulerInteg(rbd::Joint::Type jType,
   using namespace rbd;
 
   Joint j(jType, axis, true, std::string("0"));
-  std::vector<double> qVec(j.params()), alphaVec(j.dof()), alphaDVec(j.dof());
+  const auto nparams = static_cast<size_t>(j.params());
+  const auto ndofs = static_cast<size_t>(j.dof());
+  std::vector<double> qVec(nparams), alphaVec(ndofs), alphaDVec(ndofs);
   for(int i = 0; i < j.params(); ++i)
   {
-    qVec[i] = q[i];
+    const auto ui = static_cast<size_t>(i);
+    qVec[ui] = q(i);
   }
   for(int i = 0; i < j.dof(); ++i)
   {
-    alphaVec[i] = alpha[i];
-    alphaDVec[i] = 0.;
+    const auto ui = static_cast<size_t>(i);
+    alphaVec[ui] = alpha(i);
+    alphaDVec[ui] = 0.;
   }
 
   sva::PTransformd initPos(j.pose(qVec));
@@ -484,15 +488,16 @@ BOOST_AUTO_TEST_CASE(FATest)
   forwardVelocity(mb, mbc);
   forwardAcceleration(mb, mbc);
 
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     BOOST_CHECK_SMALL(mbc.bodyAccB[i].vector().norm(), TOL);
   }
 
-  std::vector<rbd::Jacobian> jacs(mb.nrBodies());
+  std::vector<rbd::Jacobian> jacs(static_cast<size_t>(mb.nrBodies()));
   for(int i = 0; i < mb.nrBodies(); ++i)
   {
-    jacs[i] = rbd::Jacobian(mb, mb.body(i).name());
+    const auto ui = static_cast<size_t>(i);
+    jacs[ui] = rbd::Jacobian(mb, mb.body(i).name());
   }
 
   Eigen::MatrixXd fullJac(6, mb.nrDof());
@@ -514,7 +519,7 @@ BOOST_AUTO_TEST_CASE(FATest)
     forwardVelocity(mb, mbc);
     forwardAcceleration(mb, mbc);
 
-    for(int j = 0; j < mb.nrBodies(); ++j)
+    for(size_t j = 0; j < static_cast<size_t>(mb.nrBodies()); ++j)
     {
       const Eigen::MatrixXd & jac = jacs[j].bodyJacobian(mb, mbc);
       const Eigen::MatrixXd & jacDot = jacs[j].bodyJacobianDot(mb, mbc);

--- a/tests/CoMTest.cpp
+++ b/tests/CoMTest.cpp
@@ -279,24 +279,28 @@ BOOST_AUTO_TEST_CASE(CoMJacobianDummyTest)
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
-      mbc.alphaD[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
+      mbc.alphaD[ui][uj] = 1.;
 
       testJacCoMVelAcc(mb, mbc, comJac);
 
-      mbc.alpha[i][j] = 0.;
-      mbc.alphaD[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
+      mbc.alphaD[ui][uj] = 0.;
     }
   }
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
-      mbc.alphaD[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
+      mbc.alphaD[ui][uj] = 1.;
 
       testJacCoMVelAcc(mb, mbc, comJac);
     }
@@ -315,24 +319,28 @@ BOOST_AUTO_TEST_CASE(CoMJacobianDummyTest)
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
-      mbc.alphaD[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
+      mbc.alphaD[ui][uj] = 1.;
 
       testJacCoMVelAcc(mb, mbc, comJac);
 
-      mbc.alpha[i][j] = 0.;
-      mbc.alphaD[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
+      mbc.alphaD[ui][uj] = 0.;
     }
   }
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
-      mbc.alphaD[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
+      mbc.alphaD[ui][uj] = 1.;
 
       testJacCoMVelAcc(mb, mbc, comJac);
     }
@@ -357,9 +365,11 @@ BOOST_AUTO_TEST_CASE(CoMJacobianDummyTest)
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
       forwardAcceleration(mb, mbc);
 
@@ -370,15 +380,17 @@ BOOST_AUTO_TEST_CASE(CoMJacobianDummyTest)
       BOOST_CHECK_EQUAL(jacDot.cols(), mb.nrDof());
 
       BOOST_CHECK_SMALL((jacDot_diff - jacDot).norm(), TOL);
-      mbc.alpha[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
     }
   }
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
       forwardAcceleration(mb, mbc);
 
@@ -389,7 +401,7 @@ BOOST_AUTO_TEST_CASE(CoMJacobianDummyTest)
       BOOST_CHECK_EQUAL(jacDot.cols(), mb.nrDof());
 
       BOOST_CHECK_SMALL((jacDot_diff - jacDot).norm(), TOL);
-      mbc.alpha[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
     }
   }
   mbc.alpha = {{}, {0.}, {0.}, {0.}, {0., 0., 0.}};
@@ -404,9 +416,11 @@ BOOST_AUTO_TEST_CASE(CoMJacobianDummyTest)
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
       forwardAcceleration(mb, mbc);
 
@@ -417,15 +431,17 @@ BOOST_AUTO_TEST_CASE(CoMJacobianDummyTest)
       BOOST_CHECK_EQUAL(jacDot.cols(), mb.nrDof());
 
       BOOST_CHECK_SMALL((jacDot_diff - jacDot).norm(), TOL);
-      mbc.alpha[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
     }
   }
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
       forwardAcceleration(mb, mbc);
 
@@ -436,7 +452,7 @@ BOOST_AUTO_TEST_CASE(CoMJacobianDummyTest)
       BOOST_CHECK_EQUAL(jacDot.cols(), mb.nrDof());
 
       BOOST_CHECK_SMALL((jacDot_diff - jacDot).norm(), TOL);
-      mbc.alpha[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
     }
   }
   mbc.alpha = {{}, {0.}, {0.}, {0.}, {0., 0., 0.}};
@@ -470,7 +486,7 @@ BOOST_AUTO_TEST_CASE(CoMJacobianTest)
 
   std::tie(mb, mbc, mbg) = makeXYZSarmRandomCoM();
 
-  std::vector<double> weight(mb.nrBodies());
+  std::vector<double> weight(static_cast<size_t>(mb.nrBodies()));
   for(std::size_t i = 0; i < weight.size(); ++i)
   {
     weight[i] = Eigen::Matrix<double, 1, 1>::Random()(0);
@@ -506,9 +522,11 @@ BOOST_AUTO_TEST_CASE(CoMJacobianTest)
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
 
       MatrixXd jacDotMat = comJac.jacobianDot(mb, mbc);
@@ -518,15 +536,17 @@ BOOST_AUTO_TEST_CASE(CoMJacobianTest)
       BOOST_CHECK_EQUAL(jacDotMat.cols(), mb.nrDof());
 
       BOOST_CHECK_SMALL((jacDotMat - jacDotDummyMat).norm(), TOL);
-      mbc.alpha[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
     }
   }
 
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
 
       MatrixXd jacDotMat = comJac.jacobianDot(mb, mbc);

--- a/tests/DynamicsTest.cpp
+++ b/tests/DynamicsTest.cpp
@@ -113,7 +113,7 @@ void normalizeQuat(std::vector<double> & q)
 {
   Eigen::Vector4d qv(q[0], q[1], q[2], q[3]);
   double norm = qv.norm();
-  for(int i = 0; i < 4; ++i) q[i] /= norm;
+  for(size_t i = 0; i < 4; ++i) q[i] /= norm;
 }
 
 void makeRandomConfig(rbd::MultiBodyConfig & mbc)
@@ -156,9 +156,11 @@ Eigen::MatrixXd makeHFromID(const rbd::MultiBody & mb,
   int col = 0;
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbcd.alphaD[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbcd.alphaD[ui][uj] = 1.;
 
       id.inverseDynamics(mb, mbcd);
 
@@ -174,7 +176,7 @@ Eigen::MatrixXd makeHFromID(const rbd::MultiBody & mb,
 
       H.col(col) = Hd - C;
 
-      mbcd.alphaD[i][j] = 0.;
+      mbcd.alphaD[ui][uj] = 0.;
       ++col;
     }
   }

--- a/tests/IntegrationTest.cpp
+++ b/tests/IntegrationTest.cpp
@@ -63,7 +63,7 @@ std::tuple<rbd::MultiBody, rbd::MultiBodyConfig, rbd::MultiBodyGraph> makeSingle
 
 std::vector<double> randVec(int size, double rmin, double rmax, bool normed = false)
 {
-  std::vector<double> v(size, 0);
+  std::vector<double> v(static_cast<size_t>(size), 0);
   Map<VectorXd> r(&v[0], size, 1);
   r = (rmax - rmin) * VectorXd::Random(size).cwiseAbs() + VectorXd::Constant(size, rmin);
 

--- a/tests/JacobianTest.cpp
+++ b/tests/JacobianTest.cpp
@@ -140,9 +140,11 @@ void checkJacobianMatrixFromVelocity(const rbd::MultiBody & subMb,
   int col = 0;
   for(int i = 0; i < subMb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < subMb.joint(i).dof(); ++j)
     {
-      subMbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      subMbc.alpha[ui][uj] = 1.;
 
       forwardVelocity(subMb, subMbc);
 
@@ -150,7 +152,7 @@ void checkJacobianMatrixFromVelocity(const rbd::MultiBody & subMb,
 
       BOOST_CHECK_SMALL((mv - jacMat.col(col)).norm(), TOL);
 
-      subMbc.alpha[i][j] = 0.;
+      subMbc.alpha[ui][uj] = 0.;
       ++col;
     }
   }

--- a/tests/JacobianTest.cpp
+++ b/tests/JacobianTest.cpp
@@ -201,11 +201,12 @@ void checkJacobian(const rbd::MultiBody & mb, const rbd::MultiBodyConfig & mbc, 
 
   // fill subMbc
   MultiBodyConfig subMbc(subMb);
-  for(int i = 0; i < subMb.nrJoints(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(subMb.nrJoints()); ++i)
   {
-    subMbc.bodyPosW[i] = mbc.bodyPosW[jac.jointsPath()[i]];
-    subMbc.jointConfig[i] = mbc.jointConfig[jac.jointsPath()[i]];
-    subMbc.parentToSon[i] = mbc.parentToSon[jac.jointsPath()[i]];
+    const auto joint_index = static_cast<size_t>(jac.jointsPath()[i]);
+    subMbc.bodyPosW[i] = mbc.bodyPosW[joint_index];
+    subMbc.jointConfig[i] = mbc.jointConfig[joint_index];
+    subMbc.parentToSon[i] = mbc.parentToSon[joint_index];
   }
 
   // test fullJacobian
@@ -236,7 +237,8 @@ void checkJacobianRefBody(const rbd::MultiBody & mb, const rbd::MultiBodyConfig 
 
   for(size_t i = 0; i < static_cast<size_t>(subMb.nrJoints()); ++i)
   {
-    subMbc.q[i] = mbc.q[jac.jointsPath()[i]];
+    const auto joint_index = static_cast<size_t>(jac.jointsPath()[i]);
+    subMbc.q[i] = mbc.q[joint_index];
   }
 
   forwardKinematics(subMb, subMbc);

--- a/tests/JacobianTest.cpp
+++ b/tests/JacobianTest.cpp
@@ -139,16 +139,18 @@ void checkJacobianMatrixFromVelocity(const rbd::MultiBody & subMb,
   int col = 0;
   for(int i = 0; i < subMb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < subMb.joint(i).dof(); ++j)
     {
-      subMbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      subMbc.alpha[ui][uj] = 1.;
 
       forwardVelocity(subMb, subMbc);
 
       Eigen::Vector6d mv = velVec.back().vector();
       BOOST_CHECK_SMALL((mv - jacMat.col(col)).norm(), TOL);
 
-      subMbc.alpha[i][j] = 0.;
+      subMbc.alpha[ui][uj] = 0.;
       ++col;
     }
   }
@@ -177,7 +179,8 @@ void checkFullJacobianMatrix(const rbd::MultiBody & mb,
 
   for(int i = 0; i < subMb.nrJoints(); ++i)
   {
-    int joint = jac.jointsPath()[i];
+    const auto ui = static_cast<size_t>(i);
+    int joint = jac.jointsPath()[ui];
     int dof = mb.joint(i).dof();
     BOOST_CHECK_EQUAL(jacMat.block(0, subMb.jointPosInDof(i), 6, dof),
                       fullJacMat.block(0, mb.jointPosInDof(joint), 6, dof));
@@ -195,11 +198,12 @@ void checkJacobian(const rbd::MultiBody & mb, const rbd::MultiBodyConfig & mbc, 
 
   // fill subMbc
   MultiBodyConfig subMbc(subMb);
-  for(int i = 0; i < subMb.nrJoints(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(subMb.nrJoints()); ++i)
   {
-    subMbc.bodyPosW[i] = mbc.bodyPosW[jac.jointsPath()[i]];
-    subMbc.jointConfig[i] = mbc.jointConfig[jac.jointsPath()[i]];
-    subMbc.parentToSon[i] = mbc.parentToSon[jac.jointsPath()[i]];
+    const auto joint_index = static_cast<size_t>(jac.jointsPath()[i]);
+    subMbc.bodyPosW[i] = mbc.bodyPosW[joint_index];
+    subMbc.jointConfig[i] = mbc.jointConfig[joint_index];
+    subMbc.parentToSon[i] = mbc.parentToSon[joint_index];
   }
 
   // test fullJacobian
@@ -426,14 +430,16 @@ BOOST_AUTO_TEST_CASE(JacobianDotComputeTest)
   forwardKinematics(mb, mbc);
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
 
       testJacobianDot(mb, mbc, jac1);
 
-      mbc.alpha[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
     }
   }
 
@@ -445,14 +451,16 @@ BOOST_AUTO_TEST_CASE(JacobianDotComputeTest)
   forwardKinematics(mb, mbc);
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
 
       testJacobianDot(mb, mbc, jac1);
 
-      mbc.alpha[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
     }
   }
 
@@ -461,14 +469,16 @@ BOOST_AUTO_TEST_CASE(JacobianDotComputeTest)
   forwardKinematics(mb, mbc);
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
 
       testJacobianDot(mb, mbc, jac1);
 
-      mbc.alpha[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
     }
   }
 
@@ -477,23 +487,27 @@ BOOST_AUTO_TEST_CASE(JacobianDotComputeTest)
   forwardKinematics(mb, mbc);
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
 
       testJacobianDot(mb, mbc, jac1);
 
-      mbc.alpha[i][j] = 0.;
+      mbc.alpha[ui][uj] = 0.;
     }
   }
 
   // test with all joint velocity
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
 
       testJacobianDot(mb, mbc, jac1);
@@ -505,9 +519,11 @@ BOOST_AUTO_TEST_CASE(JacobianDotComputeTest)
   Jacobian jacP(mb, "b3", Vector3d::Random() * 10.);
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mb.joint(i).dof(); ++j)
     {
-      mbc.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbc.alpha[ui][uj] = 1.;
       forwardVelocity(mb, mbc);
 
       testJacobianDot(mb, mbc, jacP);
@@ -530,9 +546,11 @@ BOOST_AUTO_TEST_CASE(JacobianDotComputeTest)
 
   for(int i = 0; i < mbF.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mbF.joint(i).dof(); ++j)
     {
-      mbcF.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbcF.alpha[ui][uj] = 1.;
       forwardVelocity(mbF, mbcF);
 
       testJacobianDot(mbF, mbcF, jacF);
@@ -549,9 +567,11 @@ BOOST_AUTO_TEST_CASE(JacobianDotComputeTest)
 
   for(int i = 0; i < mbF.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     for(int j = 0; j < mbF.joint(i).dof(); ++j)
     {
-      mbcF.alpha[i][j] = 1.;
+      const auto uj = static_cast<size_t>(j);
+      mbcF.alpha[ui][uj] = 1.;
       forwardVelocity(mbF, mbcF);
 
       testJacobianDot(mbF, mbcF, jacF);

--- a/tests/JacobianTest.cpp
+++ b/tests/JacobianTest.cpp
@@ -28,8 +28,8 @@
 
 // Arm
 #include "SSSarm.h"
-#include "XYZSarm.h"
 #include "XXXdualarm.h"
+#include "XYZSarm.h"
 
 const double TOL = 0.0000001;
 
@@ -254,7 +254,6 @@ void checkJacobianRefBody(const rbd::MultiBody & mb, const rbd::MultiBodyConfig 
   checkJacobianMatrixFromVelocity(subMb, subMbc, subMbc.bodyVelB, jac_mat_w);
 }
 
-
 BOOST_AUTO_TEST_CASE(JacobianComputeTest)
 {
   using namespace Eigen;
@@ -313,14 +312,19 @@ BOOST_AUTO_TEST_CASE(JacobianRefBodyTest)
   Jacobian jac1(mb, "b31", "b32");
   Jacobian jac2(mb, "b32", "b31");
 
-  mbc.q = {{},{0.}, {0.}, {0.}, {0.}, {0.}};
+  mbc.q = {{}, {0.}, {0.}, {0.}, {0.}, {0.}};
   forwardKinematics(mb, mbc);
   forwardVelocity(mb, mbc);
 
   checkJacobianRefBody(mb, mbc, jac1);
   checkJacobianRefBody(mb, mbc, jac2);
 
-  mbc.q = {{}, {cst::pi<double>() / 2.}, {cst::pi<double>() / 3.}, {cst::pi<double>() / 4.}, {cst::pi<double>() / 5.}, {cst::pi<double>() / 6.}};
+  mbc.q = {{},
+           {cst::pi<double>() / 2.},
+           {cst::pi<double>() / 3.},
+           {cst::pi<double>() / 4.},
+           {cst::pi<double>() / 5.},
+           {cst::pi<double>() / 6.}};
   forwardKinematics(mb, mbc);
   forwardVelocity(mb, mbc);
 
@@ -340,7 +344,6 @@ BOOST_AUTO_TEST_CASE(JacobianRefBodyTest)
   MultiBodyConfig mbcErr(mbErr);
   BOOST_CHECK_THROW(jac1.sJacobian(mbErr, mbcErr), std::domain_error);
 }
-
 
 BOOST_AUTO_TEST_CASE(JacobianComputeTestFreeFlyer)
 {

--- a/tests/JacobianTest.cpp
+++ b/tests/JacobianTest.cpp
@@ -316,14 +316,18 @@ BOOST_AUTO_TEST_CASE(JacobianRefBodyTest)
   Jacobian jac1(mb, "b31", "b32");
   Jacobian jac2(mb, "b32", "b31");
 
-  mbc.q = {{}, {0.}, {0.}, {0.}, {0.}, {0.}};
+  Quaterniond quat(AngleAxisd(cst::pi<double>() / 2., Vector3d::UnitX())
+                   * AngleAxisd(cst::pi<double>() / 8., Vector3d::UnitZ()));
+  Vector3d tran = Vector3d::Random() * 10.;
+
+  mbc.q = {{quat.w(), quat.x(), quat.y(), quat.z(), tran.x(), tran.y(), tran.z()}, {0.}, {0.}, {0.}, {0.}, {0.}};
   forwardKinematics(mb, mbc);
   forwardVelocity(mb, mbc);
 
   checkJacobianRefBody(mb, mbc, jac1);
   checkJacobianRefBody(mb, mbc, jac2);
 
-  mbc.q = {{},
+  mbc.q = {{quat.w(), quat.x(), quat.y(), quat.z(), tran.x(), tran.y(), tran.z()},
            {cst::pi<double>() / 2.},
            {cst::pi<double>() / 3.},
            {cst::pi<double>() / 4.},

--- a/tests/MomentumTest.cpp
+++ b/tests/MomentumTest.cpp
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(centroidalMomentum)
   // test J·q against CentroidalMomentumMatrix::momentum
   for(int i = 0; i < 50; ++i)
   {
-    std::vector<double> weight(mb.nrBodies());
+    std::vector<double> weight(static_cast<size_t>(mb.nrBodies()));
     for(std::size_t i = 0; i < weight.size(); ++i)
     {
       weight[i] = Eigen::Matrix<double, 1, 1>::Random()(0);
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(centroidalMomentumDot)
   // test JDot·q against CentroidalMomentumMatrix::normalMomentumDot
   for(int i = 0; i < 50; ++i)
   {
-    std::vector<double> weight(mb.nrBodies());
+    std::vector<double> weight(static_cast<size_t>(mb.nrBodies()));
     for(std::size_t i = 0; i < weight.size(); ++i)
     {
       weight[i] = Eigen::Matrix<double, 1, 1>::Random()(0);

--- a/tests/MultiBodyTest.cpp
+++ b/tests/MultiBodyTest.cpp
@@ -218,23 +218,24 @@ void checkMultiBodyEq(const rbd::MultiBody & mb,
   BOOST_CHECK_EQUAL_COLLECTIONS(mb.transforms().begin(), mb.transforms().end(), Xt.begin(), Xt.end());
 
   // nrBodies
-  BOOST_CHECK_EQUAL(mb.nrBodies(), bodies.size());
+  BOOST_CHECK_EQUAL(static_cast<size_t>(mb.nrBodies()), bodies.size());
   // nrJoints
-  BOOST_CHECK_EQUAL(mb.nrJoints(), bodies.size());
+  BOOST_CHECK_EQUAL(static_cast<size_t>(mb.nrJoints()), bodies.size());
 
   int params = 0, dof = 0;
   for(int i = 0; i < static_cast<int>(joints.size()); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     BOOST_CHECK_EQUAL(mb.jointPosInParam(i), params);
-    BOOST_CHECK_EQUAL(mb.jointsPosInParam()[i], params);
+    BOOST_CHECK_EQUAL(mb.jointsPosInParam()[ui], params);
     BOOST_CHECK_EQUAL(mb.sJointPosInParam(i), params);
 
     BOOST_CHECK_EQUAL(mb.jointPosInDof(i), dof);
-    BOOST_CHECK_EQUAL(mb.jointsPosInDof()[i], dof);
+    BOOST_CHECK_EQUAL(mb.jointsPosInDof()[ui], dof);
     BOOST_CHECK_EQUAL(mb.sJointPosInDof(i), dof);
 
-    params += joints[i].params();
-    dof += joints[i].dof();
+    params += joints[ui].params();
+    dof += joints[ui].dof();
   }
 
   BOOST_CHECK_EQUAL(params, mb.nrParams());
@@ -563,7 +564,8 @@ BOOST_AUTO_TEST_CASE(MakeMultiBodyTest)
 
   for(int i = 0; i < mb4.nrBodies(); ++i)
   {
-    BOOST_CHECK_EQUAL(mb4.body(i).inertia().momentum(), bCom[i]);
+    const auto ui = static_cast<size_t>(i);
+    BOOST_CHECK_EQUAL(mb4.body(i).inertia().momentum(), bCom[ui]);
   }
 }
 
@@ -683,13 +685,14 @@ BOOST_AUTO_TEST_CASE(MultiBodyConfigFunction2)
     std::vector<double> zp = mb.joint(i).zeroParam();
     std::vector<double> zd = mb.joint(i).zeroDof();
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(mbc.q[i].begin(), mbc.q[i].end(), zp.begin(), zp.end());
-    BOOST_CHECK_EQUAL_COLLECTIONS(mbc.alpha[i].begin(), mbc.alpha[i].end(), zd.begin(), zd.end());
-    BOOST_CHECK_EQUAL_COLLECTIONS(mbc.alphaD[i].begin(), mbc.alphaD[i].end(), zd.begin(), zd.end());
-    BOOST_CHECK_EQUAL_COLLECTIONS(mbc.jointTorque[i].begin(), mbc.jointTorque[i].end(), zd.begin(), zd.end());
+    const auto ui = static_cast<size_t>(i);
+    BOOST_CHECK_EQUAL_COLLECTIONS(mbc.q[ui].begin(), mbc.q[ui].end(), zp.begin(), zp.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(mbc.alpha[ui].begin(), mbc.alpha[ui].end(), zd.begin(), zd.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(mbc.alphaD[ui].begin(), mbc.alphaD[ui].end(), zd.begin(), zd.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(mbc.jointTorque[ui].begin(), mbc.jointTorque[ui].end(), zd.begin(), zd.end());
   }
 
-  for(int i = 0; i < mb.nrBodies(); ++i)
+  for(size_t i = 0; i < static_cast<size_t>(mb.nrBodies()); ++i)
   {
     BOOST_CHECK_EQUAL(mbc.force[i].vector(), Vector6d::Zero());
   }
@@ -831,7 +834,8 @@ BOOST_AUTO_TEST_CASE(MultiBodyBaseTransformTest)
   // since the multibody is construct with the old body linking api
   // we must add an offset to joint origin of mb3 that correspond mb0 transform
   // to body base
-  mb3 = mbg.makeMultiBody("b3", true, mb3Surface * mb0ToBase["b3"] * mbc0.bodyPosW[mb0.bodyIndexByName("b3")],
+  mb3 = mbg.makeMultiBody("b3", true,
+                          mb3Surface * mb0ToBase["b3"] * mbc0.bodyPosW[static_cast<size_t>(mb0.bodyIndexByName("b3"))],
                           mb3Surface);
   rbd::ConfigConverter mb0ToMb3(mb0, mb3);
   mbc3 = rbd::MultiBodyConfig(mb3);
@@ -839,7 +843,8 @@ BOOST_AUTO_TEST_CASE(MultiBodyBaseTransformTest)
   rbd::forwardKinematics(mb3, mbc3);
   auto mb3ToBase = mbg.bodiesBaseTransform("b3", mb3Surface);
 
-  mb4 = mbg.makeMultiBody("b4", true, mb4Surface * mb0ToBase["b4"] * mbc0.bodyPosW[mb0.bodyIndexByName("b4")],
+  mb4 = mbg.makeMultiBody("b4", true,
+                          mb4Surface * mb0ToBase["b4"] * mbc0.bodyPosW[static_cast<size_t>(mb0.bodyIndexByName("b4"))],
                           mb4Surface);
   mbc4 = rbd::MultiBodyConfig(mb4);
   rbd::ConfigConverter mb0ToMb4(mb0, mb4);
@@ -850,13 +855,14 @@ BOOST_AUTO_TEST_CASE(MultiBodyBaseTransformTest)
   for(int bi = 0; bi < mb0.nrBodies(); ++bi)
   {
     std::string name = mb0.body(bi).name();
-    int mb3Index = mb3.bodyIndexByName(name);
-    int mb4Index = mb4.bodyIndexByName(name);
+    const auto mb3Index = static_cast<size_t>(mb3.bodyIndexByName(name));
+    const auto mb4Index = static_cast<size_t>(mb4.bodyIndexByName(name));
+    const auto ubi = static_cast<size_t>(bi);
     BOOST_CHECK_SMALL(
-        ((mb0ToBase[name] * mbc0.bodyPosW[bi]).matrix() - (mb3ToBase[name] * mbc3.bodyPosW[mb3Index]).matrix()).norm(),
+        ((mb0ToBase[name] * mbc0.bodyPosW[ubi]).matrix() - (mb3ToBase[name] * mbc3.bodyPosW[mb3Index]).matrix()).norm(),
         1e-8);
     BOOST_CHECK_SMALL(
-        ((mb0ToBase[name] * mbc0.bodyPosW[bi]).matrix() - (mb4ToBase[name] * mbc4.bodyPosW[mb4Index]).matrix()).norm(),
+        ((mb0ToBase[name] * mbc0.bodyPosW[ubi]).matrix() - (mb4ToBase[name] * mbc4.bodyPosW[mb4Index]).matrix()).norm(),
         1e-8);
   }
 }

--- a/tests/XXXdualarm.h
+++ b/tests/XXXdualarm.h
@@ -56,9 +56,14 @@ std::tuple<rbd::MultiBody, rbd::MultiBodyConfig, rbd::MultiBodyGraph> makeXXXdua
   mbg.addJoint(j21);
   mbg.addJoint(j22);
 
-  //  Root     j0       j1     j2
-  //  ---- b0 ---- b1 ---- b2 ----b3
-  //  Base    RevX   RevX    RevX
+  //                          j21
+  //                     b21 ----- b31
+  //                j11 /
+  //  Root      j0     /
+  //  ----- b0 ----- b1
+  //  Base             \
+  //                j21 \     j22
+  //                     b22 ----- b32
 
   PTransformd to(Vector3d(0., 1., 0.));
   PTransformd to1(Vector3d(0., 1., 1.));

--- a/tests/XXXdualarm.h
+++ b/tests/XXXdualarm.h
@@ -56,14 +56,14 @@ std::tuple<rbd::MultiBody, rbd::MultiBodyConfig, rbd::MultiBodyGraph> makeXXXdua
   mbg.addJoint(j21);
   mbg.addJoint(j22);
 
-  //                          j21
-  //                     b21 ----- b31
-  //                j11 /
-  //  Root      j0     /
+  //                    j11       j21
+  //                   -----  b21 ----- b31
+  //                  |
+  //  Root      j0    |
   //  ----- b0 ----- b1
-  //  Base             \
-  //                j21 \     j22
-  //                     b22 ----- b32
+  //  Base            |
+  //                  | j21       j22
+  //                   -----  b22 ----- b32
 
   PTransformd to(Vector3d(0., 1., 0.));
   PTransformd to1(Vector3d(0., 1., 1.));

--- a/tests/XXXdualarm.h
+++ b/tests/XXXdualarm.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+// includes
+// std
+#include <tuple>
+
+// RBDyn
+#include "RBDyn/Body.h"
+#include "RBDyn/Joint.h"
+#include "RBDyn/MultiBody.h"
+#include "RBDyn/MultiBodyConfig.h"
+#include "RBDyn/MultiBodyGraph.h"
+
+/// @return A simple XXX arm with Y as up axis.
+std::tuple<rbd::MultiBody, rbd::MultiBodyConfig, rbd::MultiBodyGraph> makeXXXdualarm(bool isFixed = true)
+{
+  using namespace Eigen;
+  using namespace sva;
+  using namespace rbd;
+
+  MultiBodyGraph mbg;
+
+  double mass = 1.;
+  Matrix3d I = Matrix3d::Identity();
+  Vector3d h = Vector3d::Zero();
+
+  RBInertiad rbi(mass, h, I);
+
+  Body b0(rbi, "b0");
+  Body b1(rbi, "b1");
+  Body b21(rbi, "b21");
+  Body b22(rbi, "b22");
+  Body b31(rbi, "b31");
+  Body b32(rbi, "b32");
+
+  mbg.addBody(b0);
+  mbg.addBody(b1);
+  mbg.addBody(b21);
+  mbg.addBody(b22);
+  mbg.addBody(b31);
+  mbg.addBody(b32);
+
+  Joint j0(Joint::RevX, true, "j0");
+  Joint j11(Joint::RevX, true, "j11");
+  Joint j12(Joint::RevX, true, "j12");
+  Joint j21(Joint::RevX, true, "j21");
+  Joint j22(Joint::RevX, true, "j22");
+
+  mbg.addJoint(j0);
+  mbg.addJoint(j11);
+  mbg.addJoint(j12);
+  mbg.addJoint(j21);
+  mbg.addJoint(j22);
+
+  //  Root     j0       j1     j2
+  //  ---- b0 ---- b1 ---- b2 ----b3
+  //  Base    RevX   RevX    RevX
+
+  PTransformd to(Vector3d(0., 1., 0.));
+  PTransformd to1(Vector3d(0., 1., 1.));
+  PTransformd to2(Vector3d(0., 1., -1.));
+  PTransformd from(Vector3d(0., -1., 0.));
+
+  mbg.linkBodies("b0", to, "b1", from, "j0");
+  mbg.linkBodies("b1", to1, "b21", from, "j11");
+  mbg.linkBodies("b1", to2, "b22", from, "j12");
+  mbg.linkBodies("b21", to, "b31", from, "j21");
+  mbg.linkBodies("b22", to, "b32", from, "j22");
+
+  MultiBody mb = mbg.makeMultiBody("b0", isFixed);
+
+  MultiBodyConfig mbc(mb);
+  mbc.zero(mb);
+
+  return std::make_tuple(mb, mbc, mbg);
+}


### PR DESCRIPTION
This PR brings two major improvements:
1. The ability to compute a Jacobian using any body as reference, without having to reconstruct a new graph. Thanks to @sonny-tarbouriech for the original implementation
2. Turn `Werror` back on. All warnings have been fixed and the CI passes on all platforms. The main sources of warnings were:
    1. Pessimistic moves: things like `return std::move(obj);` which disables copy elision
    2. signed/unsigned integer implicit conversions. All indexing is based on signed integers (partly to handle the -1 case) but STL containers use unsigned integers for size and indexing. All conversions are now explicit and performed using `static_cast`