### PR TITLE
add mbc member 'bodyAccW'

### DIFF
--- a/src/RBDyn/MultiBodyConfig.cpp
+++ b/src/RBDyn/MultiBodyConfig.cpp
@@ -18,7 +18,7 @@ namespace rbd
 MultiBodyConfig::MultiBodyConfig(const MultiBody & mb)
 : q(mb.nrJoints()), alpha(mb.nrJoints()), alphaD(mb.nrJoints()), force(mb.nrBodies()), jointConfig(mb.nrJoints()),
   jointVelocity(mb.nrJoints()), jointTorque(mb.nrJoints()), motionSubspace(mb.nrJoints()), bodyPosW(mb.nrBodies()),
-  parentToSon(mb.nrBodies()), bodyVelW(mb.nrBodies()), bodyVelB(mb.nrBodies()), bodyAccB(mb.nrBodies()),
+  parentToSon(mb.nrBodies()), bodyVelW(mb.nrBodies()), bodyAccW(mb.nrBodies()), bodyVelB(mb.nrBodies()), bodyAccB(mb.nrBodies()),
   gravity(0., 9.81, 0.)
 {
   for(int i = 0; i < static_cast<int>(q.size()); ++i)
@@ -367,6 +367,7 @@ void checkMatchBodyVel(const MultiBody & mb, const MultiBodyConfig & mbc)
 
 void checkMatchBodyAcc(const MultiBody & mb, const MultiBodyConfig & mbc)
 {
+  checkMatchBodiesVector(mb, mbc.bodyAccW, "bodyAccW");
   checkMatchBodiesVector(mb, mbc.bodyAccB, "bodyAccB");
 }
 

--- a/src/RBDyn/RBDyn/MultiBodyConfig.h
+++ b/src/RBDyn/RBDyn/MultiBodyConfig.h
@@ -61,6 +61,9 @@ struct RBDYN_DLLAPI MultiBodyConfig
   /// Bodies speed in world coordinate.
   std::vector<sva::MotionVecd> bodyVelW;
 
+  /// Bodies acceleration in world coordinate.
+  std::vector<sva::MotionVecd> bodyAccW;
+
   /// Bodies speed in Body coordinate.
   std::vector<sva::MotionVecd> bodyVelB;
 
@@ -220,7 +223,8 @@ RBDYN_DLLAPI void checkMatchParentToSon(const MultiBody & mb, const MultiBodyCon
 /// (mbc.bodyVelW, mbc.bodyVelB).
 RBDYN_DLLAPI void checkMatchBodyVel(const MultiBody & mb, const MultiBodyConfig & mbc);
 
-/// @throw std::domain_error If there is a mismatch between mb and mbc.bodyAccB.
+/// @throw std::domain_error If there is a mismatch between mb and 
+/// (mbc.bodyAccW, mbc.bodyAccB).
 RBDYN_DLLAPI void checkMatchBodyAcc(const MultiBody & mb, const MultiBodyConfig & mbc);
 
 /// @throw std::domain_error If there is a mismatch between mb and mbc.jointConfig.


### PR DESCRIPTION
It would be convenient to access bodyAccW() in MultiBodyConfig.
I added the corresponding member, but it still need to be computed correctly. Is this done in IS.cpp and ID.cpp? And how?