### PR TITLE
[export] Ensure that filenames are prefixed by file:// or package://

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
         build-type: [Debug, RelWithDebInfo]
         compiler: [gcc, clang]
         exclude:
@@ -43,6 +43,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+    - name: Install pip for Python 2 (Ubuntu 20.04)
+      run: |
+        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
+        sudo python2 get-pip.py
+        rm -f get-pip.py
+      if: matrix.os == 'ubuntu-20.04'
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master
       with:

--- a/src/parsers/RBDyn/parsers/common.h
+++ b/src/parsers/RBDyn/parsers/common.h
@@ -159,6 +159,14 @@ RBDYN_PARSERS_DLLAPI ParserResult from_file(const std::string & file_path,
                                             const std::string & base_link = "",
                                             bool with_virtual_links = true,
                                             const std::string spherical_suffix = "_spherical");
+/**
+ * \brief Ensures that a path is prefixed by either package:// or file://
+ *
+ * Some ROS tools (such as rviz) require even local paths to be explicitely prefixed. Thus
+ * - If a path is already prefixed by file:// or package://, leave it unchanged.
+ * - If a path has no prefix, assume it is a local path and add the file:// prefix
+ */
+RBDYN_PARSERS_DLLAPI std::string prefix_path(const std::string & path);
 
 } // namespace parsers
 

--- a/src/parsers/common.cpp
+++ b/src/parsers/common.cpp
@@ -35,6 +35,18 @@ ParserResult from_file(const std::string & file_path,
   }
 }
 
+std::string prefix_path(const std::string & path)
+{
+  if(path.rfind("package://", 0) == 0 || path.rfind("file://", 0) == 0)
+  {
+    return path;
+  }
+  else
+  {
+    return std::string{"file://"} + path;
+  }
+}
+
 } // namespace parsers
 
 } // namespace rbd

--- a/src/parsers/to_urdf.cpp
+++ b/src/parsers/to_urdf.cpp
@@ -145,7 +145,7 @@ std::string to_urdf(const ParserResult & res)
           {
             const auto & texture = boost::get<Material::Texture>(material.data);
             auto texture_node = doc.NewElement("texture");
-            texture_node->SetAttribute("filename", texture.filename.c_str());
+            texture_node->SetAttribute("filename", prefix_path(texture.filename).c_str());
             material_node->InsertEndChild(texture_node);
           }
           visual_node->InsertEndChild(material_node);
@@ -175,7 +175,7 @@ std::string to_urdf(const ParserResult & res)
           {
             auto node = doc.NewElement("mesh");
             const auto mesh = boost::get<Geometry::Mesh>(visual.geometry.data);
-            node->SetAttribute("filename", mesh.filename.c_str());
+            node->SetAttribute("filename", prefix_path(mesh.filename).c_str());
             set_vec3d(node, "scale", Eigen::Vector3d::Constant(mesh.scale));
             geometry_node->InsertEndChild(node);
           }

--- a/src/parsers/to_yaml.cpp
+++ b/src/parsers/to_yaml.cpp
@@ -134,7 +134,7 @@ std::string to_yaml(const ParserResult & res)
           {
             const auto & texture = boost::get<Material::Texture>(material.data);
             doc << Key << "texture" << Value << BeginMap;
-            doc << Key << "filename" << Value << texture.filename;
+            doc << Key << "filename" << Value << prefix_path(texture.filename);
             doc << EndMap;
           }
           doc << EndMap;
@@ -165,7 +165,7 @@ std::string to_yaml(const ParserResult & res)
           {
             doc << Key << "mesh" << BeginMap;
             const auto mesh = boost::get<Geometry::Mesh>(visual.geometry.data);
-            doc << Key << "filename" << Value << mesh.filename;
+            doc << Key << "filename" << Value << prefix_path(mesh.filename);
             doc << Key << "scale" << Value << mesh.scale;
             doc << EndMap;
           }

--- a/tests/ParsersTestUtils.h
+++ b/tests/ParsersTestUtils.h
@@ -75,12 +75,12 @@ rbd::parsers::ParserResult createRobot()
     rbd::parsers::Visual v1, v2;
     rbd::parsers::Geometry::Mesh mesh;
     v1.origin = create_ptransform(0.1, 0.2, 0.3, 0, 0, 0);
-    mesh.filename = "test_mesh1.dae";
+    mesh.filename = "file://test_mesh1.dae";
     v1.geometry.type = rbd::parsers::Geometry::Type::MESH;
     v1.geometry.data = mesh;
 
     v2.origin = create_ptransform(0, 0, 0, 0, 0, 0);
-    mesh.filename = "test_mesh2.dae";
+    mesh.filename = "file://test_mesh2.dae";
     v2.geometry.type = rbd::parsers::Geometry::Type::MESH;
     v2.geometry.data = mesh;
 
@@ -143,7 +143,7 @@ rbd::parsers::ParserResult createRobot()
     v1.geometry.type = rbd::parsers::Geometry::Type::SUPERELLIPSOID;
     v1.geometry.data = superellipsoid;
     v1.material.type = rbd::parsers::Material::Type::TEXTURE;
-    v1.material.data = rbd::parsers::Material::Texture{"/some/texture.png"};
+    v1.material.data = rbd::parsers::Material::Texture{"file:///some/texture.png"};
 
     res.visual["b4"] = {v1};
   }
@@ -229,13 +229,13 @@ const std::string XYZSarmUrdf(
       <visual>
         <origin rpy="0. 0. 0." xyz=".1 .2 .3"/>
         <geometry>
-          <mesh filename="test_mesh1.dae"/>
+          <mesh filename="file://test_mesh1.dae"/>
         </geometry>
       </visual>
       <visual>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
-          <mesh filename="test_mesh2.dae"/>
+          <mesh filename="file://test_mesh2.dae"/>
         </geometry>
       </visual>
       <visual>
@@ -306,7 +306,7 @@ const std::string XYZSarmUrdf(
           <superellipsoid size="0.1 0.2 0.3" epsilon1="0.5" epsilon2="1"/>
         </geometry>
         <material name="Texture">
-          <texture filename="/some/texture.png" />
+          <texture filename="file:///some/texture.png" />
         </material>
       </visual>
     </link>
@@ -364,13 +364,13 @@ const std::string XYZSarmYaml(
             rpy: [0, 0, 0]
           geometry:
             mesh:
-              filename: test_mesh1.dae
+              filename: file://test_mesh1.dae
         - frame:
             xyz: [0, 0, 0]
             rpy: [0, 0, 0]
           geometry:
             mesh:
-              filename: test_mesh2.dae
+              filename: file://test_mesh2.dae
         - frame:
             xyz: [0, 0, 0]
             rpy: [0, 0, 0]
@@ -471,7 +471,7 @@ const std::string XYZSarmYaml(
           material:
             name: Texture
             texture:
-              filename: /some/texture.png
+              filename: file:///some/texture.png
   joints:
     - name: j0
       parent: b0


### PR DESCRIPTION
This PR ensures that filenames in the `urdf`/`yaml` obtained by `to_urdf`/`to_yaml` are always prefixed by either `file://`  or `package://`. This is a requirement for a lot of ROS tools (such as rviz).

For example the following cannot be displayed in rviz
```
<mesh filename="/usr/local/share/panda_prosthesis/meshes/support_femur.stl" scale="0.001 0.001 0.001"/>
```
but with the `file://` prefix everything is fine.
```
<mesh filename="file:///usr/local/share/panda_prosthesis/meshes/support_femur.stl" scale="0.001 0.001 0.001"/>
```

Note that this assumes that in case no valid prefix is provided that the intent was to load a local file.