### PR TITLE
[parsers] Allow not to remove the filtered joints

### DIFF
--- a/src/parsers/RBDyn/parsers/common.h
+++ b/src/parsers/RBDyn/parsers/common.h
@@ -137,6 +137,94 @@ struct RBDYN_PARSERS_DLLAPI Visual
   Material material;
 };
 
+/** Options passed to the parsing function */
+struct RBDYN_PARSERS_DLLAPI ParserParameters
+{
+  /** Create a root free joint if false, fixed otherwise */
+  bool fixed_ = true;
+
+  /** The bodies in this list will be filtered, the exact behavior depends on \ref remove_filtered_links
+   *
+   * If true (default): the links in this list do not appear in the resulting MultiBody
+   *
+   * If false: the links in this list appear in the resulting MultiBody but the joints they are attached to are fixed
+   */
+  std::vector<std::string> filtered_links_ = {};
+
+  /** Control the link filter behavior
+   *
+   * If true (default): the links in \ref filtered_links_ do not appear in the resulting MultiBody
+   *
+   * If false: the links in \ref filtered_links_ appear in the resulting MultiBody but the joints they are attached to
+   * are fixed
+   */
+  bool remove_filtered_links_ = true;
+
+  /** If true, the inertia of links are moved to their CoM frame */
+  bool transform_inertia_ = true;
+
+  /** If non-empty, use this body as the base for the MultiBody, otherwise the first body in the URDF/YAML is used */
+  std::string base_link_ = "";
+
+  /** If true, bodies without inertial parameters are removed from the resulting MultiBody
+   *
+   * \note This is independent of the \ref remove_filtered_links parameter
+   */
+  bool remove_virtual_links_ = true;
+
+  /** Treat joint with this suffix as spherical joints */
+  std::string spherical_suffix_ = "_spherical";
+
+  /** Change the \ref fixed_ parameter to \param fixed and returns self */
+  inline ParserParameters & fixed(bool fixed) noexcept
+  {
+    fixed_ = fixed;
+    return *this;
+  }
+
+  /** Change the \ref filtered_links_ parameter to \param links and returns self */
+  inline ParserParameters & filtered_links(const std::vector<std::string> & links) noexcept
+  {
+    filtered_links_ = links;
+    return *this;
+  }
+
+  /** Change the \ref remove_filtered_links_ parameter to \param value and returns self */
+  inline ParserParameters & remove_filtered_links(bool value) noexcept
+  {
+    remove_filtered_links_ = value;
+    return *this;
+  }
+
+  /** Change the \ref transform_inertia_ parameter to \param value and returns self */
+  inline ParserParameters & transform_inertia(bool value) noexcept
+  {
+    transform_inertia_ = value;
+    return *this;
+  }
+
+  /** Change the \ref base_link_ parameter to \param link and returns self */
+  inline ParserParameters & base_link(const std::string & link) noexcept
+  {
+    base_link_ = link;
+    return *this;
+  }
+
+  /** Change the \ref remove_virtual_links_ parameter to \param value and returns self */
+  inline ParserParameters & remove_virtual_links(bool value) noexcept
+  {
+    remove_virtual_links_ = value;
+    return *this;
+  }
+
+  /** Change the \ref spherical_suffix_ parameter to \param suffix and returns self */
+  inline ParserParameters & spherical_suffix(const std::string & suffix) noexcept
+  {
+    spherical_suffix_ = suffix;
+    return *this;
+  }
+};
+
 struct RBDYN_PARSERS_DLLAPI ParserResult
 {
   rbd::MultiBody mb;

--- a/src/parsers/RBDyn/parsers/common.h
+++ b/src/parsers/RBDyn/parsers/common.h
@@ -247,6 +247,14 @@ RBDYN_PARSERS_DLLAPI ParserResult from_file(const std::string & file_path,
                                             const std::string & base_link = "",
                                             bool with_virtual_links = true,
                                             const std::string spherical_suffix = "_spherical");
+
+//! \brief Checks the file extension and parses it as URDF or YAML accordingly
+//!
+//! \param file_path Path to the file to parse
+//! \param params Parser parameters
+//! \return ParserResult The parsing result
+RBDYN_PARSERS_DLLAPI ParserResult from_file(const std::string & file_path, const ParserParameters & params);
+
 /**
  * \brief Ensures that a path is prefixed by either package:// or file://
  *

--- a/src/parsers/RBDyn/parsers/urdf.h
+++ b/src/parsers/RBDyn/parsers/urdf.h
@@ -36,21 +36,6 @@ RBDYN_PARSERS_DLLAPI Eigen::Vector3d attrToVector(const tinyxml2::XMLElement & d
                                                   const std::string & attr,
                                                   const Eigen::Vector3d & def = Eigen::Vector3d(0, 0, 0));
 
-RBDYN_PARSERS_DLLAPI Eigen::Matrix3d RPY(const double & r, const double & p, const double & y);
-
-RBDYN_PARSERS_DLLAPI rbd::Joint::Type rbdynFromUrdfJoint(const std::string & type);
-
-RBDYN_PARSERS_DLLAPI sva::PTransformd originFromTag(const tinyxml2::XMLElement & root, const std::string & tagName);
-RBDYN_PARSERS_DLLAPI sva::PTransformd originFromTag(const tinyxml2::XMLElement * dom);
-
-RBDYN_PARSERS_DLLAPI std::string parseMultiBodyGraphFromURDF(ParserResult & res,
-                                                             const std::string & content,
-                                                             const std::vector<std::string> & filteredLinksIn = {},
-                                                             bool transformInertia = true,
-                                                             const std::string & baseLinkIn = "",
-                                                             bool withVirtualLinks = true,
-                                                             const std::string & sphericalSuffix = "_spherical");
-
 RBDYN_PARSERS_DLLAPI ParserResult from_urdf(const std::string & content,
                                             bool fixed = true,
                                             const std::vector<std::string> & filteredLinksIn = {},
@@ -66,6 +51,10 @@ RBDYN_PARSERS_DLLAPI ParserResult from_urdf_file(const std::string & file_path,
                                                  const std::string & baseLinkIn = "",
                                                  bool withVirtualLinks = true,
                                                  const std::string & sphericalSuffix = "_spherical");
+
+RBDYN_PARSERS_DLLAPI ParserResult from_urdf(const std::string & content, const ParserParameters & params);
+
+RBDYN_PARSERS_DLLAPI ParserResult from_urdf_file(const std::string & file_path, const ParserParameters & params);
 
 RBDYN_PARSERS_DLLAPI std::string to_urdf(const ParserResult & res);
 

--- a/src/parsers/RBDyn/parsers/yaml.h
+++ b/src/parsers/RBDyn/parsers/yaml.h
@@ -30,7 +30,8 @@ public:
                 bool transform_inertia = true,
                 const std::string & base_link = "",
                 bool with_virtual_links = true,
-                const std::string & spherical_suffix = "_spherical");
+                const std::string & spherical_suffix = "_spherical",
+                bool remove_filtered_links = true);
 
   ParserResult & result()
   {
@@ -52,9 +53,12 @@ private:
   size_t joint_idx_;
   std::map<std::string, rbd::Joint::Type> joint_types_;
   std::vector<std::string> filtered_links_;
+  bool remove_filtered_links_;
   bool with_virtual_links_;
   const std::string & spherical_suffix_;
   std::unordered_map<std::string, Material> materials_;
+  std::vector<std::string> fixed_links_;
+  std::vector<std::string> removed_links_;
 
   Eigen::Matrix3d makeInertia(double ixx, double iyy, double izz, double iyz, double ixz, double ixy);
 
@@ -91,7 +95,8 @@ private:
   bool parseJointType(const YAML::Node & type,
                       const std::string & name,
                       rbd::Joint::Type & joint_type,
-                      std::string & type_name);
+                      std::string & type_name,
+                      bool force_fixed);
 
   void parseJointAxis(const YAML::Node & axis, const std::string & name, Eigen::Vector3d & joint_axis);
 
@@ -118,6 +123,10 @@ RBDYN_PARSERS_DLLAPI ParserResult from_yaml_file(const std::string & file_path,
                                                  const std::string & baseLinkIn = "",
                                                  bool withVirtualLinks = true,
                                                  const std::string & sphericalSuffix = "_spherical");
+
+RBDYN_PARSERS_DLLAPI ParserResult from_yaml(const std::string & content, const ParserParameters & params);
+
+RBDYN_PARSERS_DLLAPI ParserResult from_yaml_file(const std::string & file_path, const ParserParameters & params);
 
 RBDYN_PARSERS_DLLAPI std::string to_yaml(const ParserResult & res);
 

--- a/src/parsers/common.cpp
+++ b/src/parsers/common.cpp
@@ -16,17 +16,26 @@ ParserResult from_file(const std::string & file_path,
                        bool with_virtual_links,
                        const std::string spherical_suffix)
 {
+  return from_file(file_path, ParserParameters{}
+                                  .fixed(fixed)
+                                  .filtered_links(filtered_links)
+                                  .transform_inertia(transform_inertia)
+                                  .base_link(base_link)
+                                  .remove_virtual_links(!with_virtual_links)
+                                  .spherical_suffix(spherical_suffix));
+}
+
+ParserResult from_file(const std::string & file_path, const ParserParameters & params)
+{
   auto extension_pos = file_path.rfind('.');
   auto extension = file_path.substr(extension_pos + 1);
   if(extension == "yaml" || extension == "yml")
   {
-    return from_yaml_file(file_path, fixed, filtered_links, transform_inertia, base_link, with_virtual_links,
-                          spherical_suffix);
+    return from_yaml_file(file_path, params);
   }
   else if(extension == "urdf")
   {
-    return from_urdf_file(file_path, fixed, filtered_links, transform_inertia, base_link, with_virtual_links,
-                          spherical_suffix);
+    return from_urdf_file(file_path, params);
   }
   else
   {

--- a/src/parsers/urdf.cpp
+++ b/src/parsers/urdf.cpp
@@ -317,11 +317,7 @@ bool visualFromTag(const tinyxml2::XMLElement & dom, const MaterialCache & mater
 
 std::string parseMultiBodyGraphFromURDF(ParserResult & res,
                                         const std::string & content,
-                                        const std::vector<std::string> & filteredLinksIn,
-                                        bool transformInertia,
-                                        const std::string & baseLinkIn,
-                                        bool withVirtualLinks,
-                                        const std::string & sphericalSuffix)
+                                        const ParserParameters & params)
 {
   tinyxml2::XMLDocument doc;
   doc.Parse(content.c_str());
@@ -346,31 +342,43 @@ std::string parseMultiBodyGraphFromURDF(ParserResult & res,
   }
 
   std::vector<tinyxml2::XMLElement *> links;
-  std::vector<std::string> filteredLinks = filteredLinksIn;
-  // Extract link elements from the document, remove filtered links
+  // Keep those links but fix the joint
+  std::vector<std::string> fixed_links{};
+  // Remove those links
+  std::vector<std::string> removed_links{};
+  // Extract link elements from the document, remove filtered links if needed
   {
     tinyxml2::XMLElement * link = robot->FirstChildElement("link");
     while(link)
     {
-      std::string linkName = link->Attribute("name");
-      if(std::find(filteredLinks.begin(), filteredLinks.end(), linkName) == filteredLinks.end())
-      {
-        if(!withVirtualLinks)
+      auto handle_link = [&]() {
+        std::string linkName = link->Attribute("name");
+        bool link_has_inertia = link->FirstChildElement("inertial") != nullptr;
+        if(!link_has_inertia && params.remove_virtual_links_)
         {
-          if(link->FirstChildElement("inertial"))
+          removed_links.push_back(linkName);
+          return;
+        }
+        bool is_filtered = std::find(params.filtered_links_.begin(), params.filtered_links_.end(), linkName)
+                           != params.filtered_links_.end();
+        if(is_filtered)
+        {
+          if(params.remove_filtered_links_)
           {
-            links.push_back(link);
+            removed_links.push_back(linkName);
           }
           else
           {
-            filteredLinks.push_back(linkName);
+            fixed_links.push_back(linkName);
+            links.push_back(link);
           }
         }
         else
         {
           links.push_back(link);
         }
-      }
+      };
+      handle_link();
       link = link->NextSiblingElement("link");
     }
   }
@@ -381,7 +389,7 @@ std::string parseMultiBodyGraphFromURDF(ParserResult & res,
     return "";
   }
 
-  std::string baseLink = baseLinkIn == "" ? links[0]->Attribute("name") : baseLinkIn;
+  std::string baseLink = params.base_link_.empty() ? links[0]->Attribute("name") : params.base_link_;
 
   for(tinyxml2::XMLElement * linkDom : links)
   {
@@ -407,7 +415,7 @@ std::string parseMultiBodyGraphFromURDF(ParserResult & res,
       Eigen::Matrix3d comFrame = RPY(comRPY);
       mass = attrToDouble(*massDom, "value");
       Eigen::Matrix3d inertia = readInertia(*inertiaDom);
-      if(transformInertia)
+      if(params.transform_inertia_)
       {
         inertia_o = sva::inertiaToOrigin(inertia, mass, com, comFrame);
       }
@@ -443,6 +451,13 @@ std::string parseMultiBodyGraphFromURDF(ParserResult & res,
     res.mbg.addBody(b);
   }
 
+  auto is_removed = [&](const std::string & body) {
+    return std::find(removed_links.begin(), removed_links.end(), body) != removed_links.end();
+  };
+  auto is_fixed = [&](const std::string & body) {
+    return std::find(fixed_links.begin(), fixed_links.end(), body) != fixed_links.end();
+  };
+
   std::vector<tinyxml2::XMLElement *> joints;
   // Extract joint elements from the document, remove joints that link with filtered links
   {
@@ -451,10 +466,13 @@ std::string parseMultiBodyGraphFromURDF(ParserResult & res,
     {
       std::string parent_link = joint->FirstChildElement("parent")->Attribute("link");
       std::string child_link = joint->FirstChildElement("child")->Attribute("link");
-      if(std::find(filteredLinks.begin(), filteredLinks.end(), child_link) == filteredLinks.end()
-         && std::find(filteredLinks.begin(), filteredLinks.end(), parent_link) == filteredLinks.end())
+      if(!is_removed(parent_link) && !is_removed(child_link))
       {
         joints.push_back(joint);
+      }
+      if(is_fixed(child_link))
+      {
+        joint->SetAttribute("type", "fixed");
       }
       joint = joint->NextSiblingElement("joint");
     }
@@ -482,10 +500,14 @@ std::string parseMultiBodyGraphFromURDF(ParserResult & res,
     {
       axis = attrToVector(*axisDom, "xyz").normalized();
     }
-    rbd::Joint::Type type = rbdynFromUrdfJoint(
-        jointType, (jointName.length() >= sphericalSuffix.length()
-                    && jointName.substr(jointName.length() - sphericalSuffix.length(), sphericalSuffix.length())
-                           == sphericalSuffix));
+
+    auto is_spherical = [&](const std::string & joint) {
+      return joint.length() >= params.spherical_suffix_.length()
+             && joint.substr(joint.length() - params.spherical_suffix_.length(), params.spherical_suffix_.length())
+                    == params.spherical_suffix_;
+    };
+
+    rbd::Joint::Type type = rbdynFromUrdfJoint(jointType, is_spherical(jointName));
 
     tinyxml2::XMLElement * parentDom = jointDom->FirstChildElement("parent");
     std::string jointParent = parentDom->Attribute("link");
@@ -497,7 +519,7 @@ std::string parseMultiBodyGraphFromURDF(ParserResult & res,
 
     // Check if this is a mimic joint
     tinyxml2::XMLElement * mimicDom = jointDom->FirstChildElement("mimic");
-    if(mimicDom)
+    if(mimicDom && j.type() != rbd::Joint::Type::Fixed)
     {
       std::string mimicJoint = mimicDom->Attribute("joint");
       j.makeMimic(mimicJoint, attrToDouble(*mimicDom, "multiplier", 1.0), attrToDouble(*mimicDom, "offset"));
@@ -552,19 +574,13 @@ ParserResult from_urdf(const std::string & content,
                        bool withVirtualLinks,
                        const std::string & sphericalSuffix)
 {
-  ParserResult res;
-
-  std::string baseLink = parseMultiBodyGraphFromURDF(res, content, filteredLinksIn, transformInertia, baseLinkIn,
-                                                     withVirtualLinks, sphericalSuffix);
-
-  res.mb = res.mbg.makeMultiBody(baseLink, fixed);
-  res.mbc = rbd::MultiBodyConfig(res.mb);
-  res.mbc.zero(res.mb);
-
-  rbd::forwardKinematics(res.mb, res.mbc);
-  rbd::forwardVelocity(res.mb, res.mbc);
-
-  return res;
+  return from_urdf(content, ParserParameters{}
+                                .fixed(fixed)
+                                .filtered_links(filteredLinksIn)
+                                .transform_inertia(transformInertia)
+                                .base_link(baseLinkIn)
+                                .remove_virtual_links(!withVirtualLinks)
+                                .spherical_suffix(sphericalSuffix));
 }
 
 ParserResult from_urdf_file(const std::string & file_path,
@@ -575,13 +591,40 @@ ParserResult from_urdf_file(const std::string & file_path,
                             bool withVirtualLinks,
                             const std::string & sphericalSuffix)
 {
+  return from_urdf_file(file_path, ParserParameters{}
+                                       .fixed(fixed)
+                                       .filtered_links(filteredLinksIn)
+                                       .transform_inertia(transformInertia)
+                                       .base_link(baseLinkIn)
+                                       .remove_virtual_links(!withVirtualLinks)
+                                       .spherical_suffix(sphericalSuffix));
+}
+
+ParserResult from_urdf(const std::string & content, const ParserParameters & params)
+{
+  ParserResult res;
+
+  std::string baseLink = parseMultiBodyGraphFromURDF(res, content, params);
+
+  res.mb = res.mbg.makeMultiBody(baseLink, params.fixed_);
+  res.mbc = rbd::MultiBodyConfig(res.mb);
+  res.mbc.zero(res.mb);
+
+  rbd::forwardKinematics(res.mb, res.mbc);
+  rbd::forwardVelocity(res.mb, res.mbc);
+
+  return res;
+}
+
+ParserResult from_urdf_file(const std::string & file_path, const ParserParameters & params)
+{
   std::ifstream file(file_path);
   if(!file.is_open())
   {
     throw std::runtime_error("URDF: Can't open " + file_path + " file for reading");
   }
   std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-  return from_urdf(content, fixed, filteredLinksIn, transformInertia, baseLinkIn, withVirtualLinks, sphericalSuffix);
+  return from_urdf(content, params);
 }
 
 } // namespace parsers


### PR DESCRIPTION
This PR adds a new parameter to the parsers so that filtered links are not removed but instead this results in:
- a better dynamic model (no link mass disappear)
- a better looking model

Down the line, using this option creates some problem in mc_rtc (see https://github.com/jrl-umi3218/mc_rtc/commit/bfb315d62204ce7e9101a88c200f08e44040f8d8) and possibly in interfaces that I will look into and fix separately (the assumption is wrong in general because one could also fix the joint in the URDF)