### PR TITLE
Do not export symbols when building static libs

### DIFF
--- a/src/RBDyn/CMakeLists.txt
+++ b/src/RBDyn/CMakeLists.txt
@@ -53,7 +53,11 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
          $<INSTALL_INTERFACE:include>)
 target_link_libraries(RBDyn PUBLIC SpaceVecAlg::SpaceVecAlg)
+if(BUILD_SHARED_LIBS)
 set_target_properties(RBDyn PROPERTIES COMPILE_FLAGS "-Drbdyn_EXPORTS")
+else()
+set_target_properties(RBDyn PROPERTIES COMPILE_FLAGS "-DRBDYN_STATIC")
+endif()
 set_target_properties(RBDyn PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR}
                                        VERSION ${PROJECT_VERSION})
 set_target_properties(RBDyn PROPERTIES CXX_STANDARD 11)

--- a/src/parsers/CMakeLists.txt
+++ b/src/parsers/CMakeLists.txt
@@ -15,8 +15,12 @@ target_include_directories(
          $<INSTALL_INTERFACE:include>)
 target_link_libraries(RBDynParsers PUBLIC RBDyn tinyxml2::tinyxml2 yaml-cpp
                                           Boost::boost)
+if(BUILD_SHARED_LIBS)
 set_target_properties(RBDynParsers PROPERTIES COMPILE_FLAGS
                                               "-DRBDYN_PARSERS_EXPORTS")
+else()
+set_target_properties(RBDyn PROPERTIES COMPILE_FLAGS "-DRBDYN_STATIC")
+endif()
 set_target_properties(RBDynParsers PROPERTIES CXX_STANDARD 11)
 set_target_properties(RBDynParsers PROPERTIES EXPORT_NAME Parsers)
 set_target_properties(RBDynParsers PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR}


### PR DESCRIPTION
Do not export symbols when building static library.. I guess this should be the correct way of doing this, no?