### PR TITLE
Remove Geometry::scale 

### DIFF
--- a/binding/python/rbdyn/parsers/c_parsers.pxd
+++ b/binding/python/rbdyn/parsers/c_parsers.pxd
@@ -21,7 +21,7 @@ cdef extern from "<RBDyn/parsers/common.h>" namespace "rbd::parsers":
 
     cdef cppclass GeometryMesh "rbd::parsers::Geometry::Mesh":
         string filename
-        double scale
+        Vector3d scaleV
 
     cdef cppclass GeometryBox "rbd::parsers::Geometry::Box":
         Vector3d size

--- a/binding/python/rbdyn/parsers/parsers.pyx
+++ b/binding/python/rbdyn/parsers/parsers.pyx
@@ -40,20 +40,20 @@ cdef class GeometryMesh(object):
     property filename:
         def __get__(self):
             return self.impl.filename
-    property scale:
+    property scaleV:
         def __get__(self):
-            return self.impl.scale
+            return eigen.Vector3dFromC(self.impl.scaleV)
 
     def __richcmp__(GeometryMesh self, GeometryMesh other, int op):
         if op == 2:
             return (
                 self.impl.filename == other.impl.filename
-                and self.impl.scale == other.impl.scale
+                and self.impl.scaleV == other.impl.scaleV
             )
         elif op == 3:
             return (
                 self.impl.filename != other.impl.filename
-                and self.impl.scale != other.impl.scale
+                and self.impl.scaleV != other.impl.scaleV
             )
         else:
             raise NotImplementedError("This comparison is not supported")

--- a/src/parsers/RBDyn/parsers/common.h
+++ b/src/parsers/RBDyn/parsers/common.h
@@ -43,10 +43,9 @@ struct RBDYN_PARSERS_DLLAPI Geometry
 public:
   struct Mesh
   {
-    Mesh() : scaleV(Eigen::Vector3d::Ones()), scale(1) {}
+    Mesh() : scaleV(Eigen::Vector3d::Ones()) {}
     std::string filename;
     Eigen::Vector3d scaleV;
-    double scale;
   };
   struct Box
   {

--- a/src/parsers/urdf.cpp
+++ b/src/parsers/urdf.cpp
@@ -238,13 +238,11 @@ Geometry::Data geometryFromMesh(const tinyxml2::XMLElement & meshDom)
   if(maybeScaleV.size() == 3)
   {
     mesh.scaleV = Eigen::Map<Eigen::Vector3d>(maybeScaleV.data(), 3);
-    mesh.scale = mesh.scaleV[2];
   }
   else
   {
     assert(maybeScaleV.size() == 1);
-    mesh.scale = maybeScaleV[0];
-    mesh.scaleV.setConstant(mesh.scale);
+    mesh.scaleV.setConstant(maybeScaleV[0]);
   }
   return mesh;
 }

--- a/src/parsers/yaml.cpp
+++ b/src/parsers/yaml.cpp
@@ -317,13 +317,11 @@ bool RBDynFromYAML::parseGeometry(const YAML::Node & geometry, Geometry & data)
         if(maybeScaleV.size() == 3)
         {
           mesh_data.scaleV = Eigen::Map<Eigen::Vector3d>(maybeScaleV.data(), 3);
-          mesh_data.scale = mesh_data.scaleV(2);
         }
         else
         {
           assert(maybeScaleV.size() == 1);
-          mesh_data.scale = maybeScaleV[0];
-          mesh_data.scaleV.setConstant(mesh_data.scale);
+          mesh_data.scaleV.setConstant(maybeScaleV[0]);
         }
         has_geometry = true;
         data.data = mesh_data;

--- a/tests/ParsersTestUtils.h
+++ b/tests/ParsersTestUtils.h
@@ -77,14 +77,12 @@ inline rbd::parsers::ParserResult createRobot()
     rbd::parsers::Geometry::Mesh mesh;
     v1.origin = create_ptransform(0.1, 0.2, 0.3, 0, 0, 0);
     mesh.filename = "file://test_mesh1.dae";
-    mesh.scale = 1.0;
     mesh.scaleV = Eigen::Vector3d::Ones();
     v1.geometry.type = rbd::parsers::Geometry::Type::MESH;
     v1.geometry.data = mesh;
 
     v2.origin = create_ptransform(0, 0, 0, 0, 0, 0);
     mesh.filename = "file://test_mesh2.dae";
-    mesh.scale = 0.1;
     mesh.scaleV = Eigen::Vector3d(0.1, -0.1, 0.1);
     v2.geometry.type = rbd::parsers::Geometry::Type::MESH;
     v2.geometry.data = mesh;
@@ -168,7 +166,7 @@ namespace parsers
 
 inline bool operator==(const Geometry::Mesh & m1, const Geometry::Mesh & m2)
 {
-  return m1.scaleV == m2.scaleV && m1.scale == m2.scale && m1.filename == m2.filename;
+  return m1.scaleV == m2.scaleV && m1.filename == m2.filename;
 }
 
 inline bool operator==(const Geometry::Box & b1, const Geometry::Box & b2)


### PR DESCRIPTION
This PR proposes to remove the duplication between `double Geometry::Mesh::scale` and `Eigen::Vector3d Geometry::Mesh::scaleV`. Indeed `scaleV` contains all the necessary information and having both is unnecessary and confusing.

Loading from `urdf/yaml` still supports both a single valued or dimensional scale. Exporting always exports the dimensional scale.

See https://github.com/jrl-umi3218/mc_rtc/pull/430