### PR TITLE
:+1: update dependency for debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,6 +35,7 @@ Package: librbdyn-dev
 Section: libdevel
 Architecture: any
 Depends: pkg-config,
+         libboost-system-dev,
          libeigen3-dev (>= 3.2),
          libspacevecalg-dev,
          libtinyxml2-dev,


### PR DESCRIPTION
OS: Ubuntu 22.04 
After installing librbdyn-dev on clean environment withour pre-installed boost such as libboost-all-dev, the following error happened when use `find_package(RBDyn REQUIRED)`: 
```
CMake Error at /usr/local/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Boost (missing: Boost_INCLUDE_DIR system)
Call Stack (most recent call first):
  /usr/local/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/share/cmake-3.31/Modules/FindBoost.cmake:2409 (find_package_handle_standard_args)
  /usr/local/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  /usr/lib/x86_64-linux-gnu/cmake/RBDyn/RBDynConfig.cmake:158 (find_dependency)
  CMakeLists.txt:9 (find_package)
```
As mentioned in main [CMakeLists.txt](https://github.com/jrl-umi3218/RBDyn/blob/master/CMakeLists.txt), at least boost system is needed for unpacking this project. 
```
...
  # Note: technically we don't need system but it is likely to be here and CMake
  # <= 3.5.0 needs at least one component to define Boost::boost
  add_project_dependency(Boost REQUIRED COMPONENTS system)
endif()
```

Therefore, in order to use librbdyn-dev in environment without pre-installed libboost-system-dev, we can add libboost-system-dev into debian/control so it will be installed when librbdyn-dev is installed.  