### PR TITLE
Introduces Rotor Inertia and Gear Ratio effect

### DIFF
--- a/src/RBDyn/FD.cpp
+++ b/src/RBDyn/FD.cpp
@@ -28,6 +28,7 @@ ForwardDynamics::ForwardDynamics(const MultiBody & mb)
     dofPos_[ui] = dofP;
     dofP += mb.joint(i).dof();
   }
+  computeHIr(mb);
 }
 
 void ForwardDynamics::forwardDynamics(const MultiBody & mb, MultiBodyConfig & mbc)

--- a/src/RBDyn/FD.cpp
+++ b/src/RBDyn/FD.cpp
@@ -43,14 +43,15 @@ void ForwardDynamics::forwardDynamics(const MultiBody & mb, MultiBodyConfig & mb
   vectorToParam(tmpFd_, mbc.alphaD);
 }
 
-void ForwardDynamics::computeHIr(const MultiBody& mb)
+void ForwardDynamics::computeHIr(const MultiBody & mb)
 {
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
+    const auto ui = static_cast<size_t>(i);
     if(mb.joint(i).type() == Joint::Rev)
     {
       double gr = mb.joint(i).gearRatio();
-      HIr_(dofPos_[i], dofPos_[i]) = mb.joint(i).rotorInertia() * gr * gr;
+      HIr_(dofPos_[ui], dofPos_[ui]) = mb.joint(i).rotorInertia() * gr * gr;
     }
   }
 }

--- a/src/RBDyn/FD.cpp
+++ b/src/RBDyn/FD.cpp
@@ -15,10 +15,11 @@ namespace rbd
 
 ForwardDynamics::ForwardDynamics(const MultiBody & mb)
 : H_(mb.nrDof(), mb.nrDof()), C_(mb.nrDof()), I_st_(static_cast<size_t>(mb.nrBodies())),
-  F_(static_cast<size_t>(mb.nrJoints())), acc_(static_cast<size_t>(mb.nrBodies())),
+  F_(static_cast<size_t>(mb.nrJoints())), HIr_(mb.nrDof(), mb.nrDof()), acc_(static_cast<size_t>(mb.nrBodies())),
   f_(static_cast<size_t>(mb.nrBodies())), tmpFd_(mb.nrDof()), dofPos_(static_cast<size_t>(mb.nrJoints())),
   ldlt_(mb.nrDof())
 {
+  HIr_.setZero();
   int dofP = 0;
   for(int i = 0; i < mb.nrJoints(); ++i)
   {
@@ -39,6 +40,18 @@ void ForwardDynamics::forwardDynamics(const MultiBody & mb, MultiBodyConfig & mb
   tmpFd_ = ldlt_.solve(tmpFd_ - C_);
 
   vectorToParam(tmpFd_, mbc.alphaD);
+}
+
+void ForwardDynamics::computeHIr(const MultiBody& mb)
+{
+  for(int i = 0; i < mb.nrJoints(); ++i)
+  {
+    if(mb.joint(i).type() == Joint::Rev)
+    {
+      double gr = mb.joint(i).gearRatio();
+      HIr_(dofPos_[i], dofPos_[i]) = mb.joint(i).rotorInertia() * gr * gr;
+    }
+  }
 }
 
 void ForwardDynamics::computeH(const MultiBody & mb, const MultiBodyConfig & mbc)
@@ -90,6 +103,8 @@ void ForwardDynamics::computeH(const MultiBody & mb, const MultiBodyConfig & mbc
       }
     }
   }
+
+  H_.noalias() = H_ + HIr_;
 }
 
 void ForwardDynamics::computeC(const MultiBody & mb, const MultiBodyConfig & mbc)

--- a/src/RBDyn/RBDyn/FD.h
+++ b/src/RBDyn/RBDyn/FD.h
@@ -40,6 +40,12 @@ public:
    */
   void forwardDynamics(const MultiBody & mb, MultiBodyConfig & mbc);
 
+    /**
+   * Compute the diagonal of rotor inertias HIr that is added to the inertia matrix H.
+   * @param mb MultiBody used has model.
+   */
+  void computeHIr(const MultiBody & mb);
+
   /**
    * Compute the inertia matrix H.
    * @param mb MultiBody used has model.
@@ -97,6 +103,7 @@ private:
   // H computation
   std::vector<sva::RBInertiad> I_st_;
   std::vector<Eigen::Matrix<double, 6, Eigen::Dynamic>> F_;
+  Eigen::MatrixXd HIr_;
 
   // C computation
   std::vector<sva::MotionVecd> acc_;

--- a/src/RBDyn/RBDyn/FD.h
+++ b/src/RBDyn/RBDyn/FD.h
@@ -67,6 +67,12 @@ public:
     return H_;
   }
 
+  /// @return The inertia matrix H.
+  const Eigen::MatrixXd & HIr() const
+  {
+    return HIr_;
+  }
+
   /// @return The non linear effect vector (coriolis, gravity, external force).
   const Eigen::VectorXd & C() const
   {

--- a/src/RBDyn/RBDyn/FD.h
+++ b/src/RBDyn/RBDyn/FD.h
@@ -40,7 +40,7 @@ public:
    */
   void forwardDynamics(const MultiBody & mb, MultiBodyConfig & mbc);
 
-    /**
+  /**
    * Compute the diagonal of rotor inertias HIr that is added to the inertia matrix H.
    * @param mb MultiBody used has model.
    */

--- a/src/RBDyn/RBDyn/Joint.h
+++ b/src/RBDyn/RBDyn/Joint.h
@@ -174,6 +174,26 @@ public:
     return mimicOffset_;
   }
 
+  void setRotorInertia(double Ir)
+  {
+    Ir_ = Ir;
+  }
+
+  double rotorInertia() const
+  {
+    return Ir_;
+  }
+
+  void setGearRatio(double gr)
+  {
+    gr_ = gr;
+  }
+
+  double gearRatio() const
+  {
+    return gr_;
+  }
+
   /// @return Joint motion subspace in successor frame coordinate.
   const Eigen::Matrix<double, 6, Eigen::Dynamic> & motionSubspace() const
   {
@@ -274,6 +294,10 @@ private:
   std::string mimicName_ = "";
   double mimicMultiplier_ = 1.0;
   double mimicOffset_ = 0.0;
+
+  double Ir_ = 0.0;
+  double gr_ = 0.0;
+
 };
 
 inline std::ostream & operator<<(std::ostream & out, const Joint & b)

--- a/src/RBDyn/RBDyn/Joint.h
+++ b/src/RBDyn/RBDyn/Joint.h
@@ -297,7 +297,6 @@ private:
 
   double Ir_ = 0.0;
   double gr_ = 0.0;
-
 };
 
 inline std::ostream & operator<<(std::ostream & out, const Joint & b)

--- a/src/RBDyn/RBDyn/MultiBody.h
+++ b/src/RBDyn/RBDyn/MultiBody.h
@@ -214,6 +214,16 @@ public:
     return nrDof_;
   }
 
+  void setJointRotorInertia(int num, double Ir)
+  {
+    joints_[num].setRotorInertia(Ir);
+  }
+
+  void setJointGearRatio(int num, double gr)
+  {
+    joints_[num].setGearRatio(gr);
+  }
+
   // safe accessors version for python binding
 
   /** Safe version of @see bodies.

--- a/src/RBDyn/RBDyn/MultiBody.h
+++ b/src/RBDyn/RBDyn/MultiBody.h
@@ -216,12 +216,12 @@ public:
 
   void setJointRotorInertia(int num, double Ir)
   {
-    joints_[num].setRotorInertia(Ir);
+    joints_[static_cast<std::size_t>(num)].setRotorInertia(Ir);
   }
 
   void setJointGearRatio(int num, double gr)
   {
-    joints_[num].setGearRatio(gr);
+    joints_[static_cast<std::size_t>(num)].setGearRatio(gr);
   }
 
   // safe accessors version for python binding


### PR DESCRIPTION
This PR extends the **forward dynamics** implementation by introducing explicit the effect **rotor inertia** and **gear ratio** into the generalized inertia matrix.

Specifically:
- Modifies Joint & MultiBody:
  - Added `Ir_` and `gr_` fields (rotor inertia, gear ratio) in `Joint`, with simple getters/setters.
  - Exposed `setJointRotorInertia(int, double)` and `setJointGearRatio(int, double)` in `MultiBody`.

- FD:
  - Introduced a new diagonal matrix `HIr_` to store effect of rotor inertia (`rotorInertia*gearRatio^2`).
  - In the constructor, zero-initialize HIr_, then call `computeHIr(mb)` to fill in each revolute joint’s rotor inertia term.
  - In `computeH(...)`, sum `HIr_` with computed inertia matrix `H_` so the final `H` includes rotor contributions.
  - Added a `HIr()` getter to use only the rotor‐inertia matrix if needed (e.g. Helps in residual estimation when using joint torque measurement).

With these edits, the forward dynamics now correctly accounts for each joint’s rotor inertia and gear ratio when building the total inertia matrix.