### PR TITLE
Adapt to boost 1.89 (remove use of boost::filesystem)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,12 @@ jobs:
         windows: |
           pip: Cython coverage numpy pytest
           github:
-            - path: eigenteam/eigen-git-mirror
-              ref: 3.3.7
+            - path: eigen-mirror/eigen
+              ref: 3.4.1
             - path: leethomason/tinyxml2
-              ref: 7.1.0
+              ref: 11.0.0
             - path: jbeder/yaml-cpp
-              ref: 29dcf92f870ee51cce8d68f8fcfe228942e8dfe1
+              ref: yaml-cpp-0.9.0
         macos-options: -DPYTHON_BINDING:BOOL=OFF
         windows-options: -DPYTHON_BINDING:BOOL=OFF
         github: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
-# Copyright 2012-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+# Copyright 2012-2026 CNRS-UM LIRMM, CNRS-AIST JRL
 #
 
 cmake_minimum_required(VERSION 3.22)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -83,7 +83,7 @@ find_package(RBDyn_TinyXML2 REQUIRED)")
 
   # Note: technically we don't need filesystem but it is likely to be here and
   # CMake <= 3.5.0 needs at least one component to define Boost::boost
-  add_project_dependency(Boost REQUIRED COMPONENTS filesystem)
+  add_project_dependency(Boost REQUIRED)
 endif()
 
 # For MSVC, set local environment variable to enable finding the built dll of

--- a/tests/fixture.hh
+++ b/tests/fixture.hh
@@ -4,24 +4,24 @@
 
 #pragma once
 
-#include <boost/filesystem/path.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/test/output_test_stream.hpp>
 #include <boost/test/test_case_template.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <iostream>
+#include <filesystem>
+namespace fs = std::filesystem;
 
 #ifdef TESTS_DATA_DIR
 // See: http://stackoverflow.com/q/26299144/1043187
 #  ifdef __NVCC__
 #    include <boost/preprocessor/stringize.hpp>
-const static boost::filesystem::path tests_data_dir(BOOST_PP_STRINGIZE(TESTS_DATA_DIR));
+const static fs::path tests_data_dir(BOOST_PP_STRINGIZE(TESTS_DATA_DIR));
 #  else
-const static boost::filesystem::path tests_data_dir(TESTS_DATA_DIR);
+const static fs::path tests_data_dir(TESTS_DATA_DIR);
 #  endif //! __NVCC__
 #else
-const static boost::filesystem::path tests_data_dir;
+const static fs::path tests_data_dir;
 #endif //! TESTS_DATA_DIR
 
 namespace rbd


### PR DESCRIPTION
Since boost 1.88, boost::filesystem has been removed entirely, use
std::filesystem instead
