### PR TITLE
python: drop python2/user/system install, use venv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,9 @@ else()
     include(FetchContent)
     FetchContent_Declare(
       "jrl-cmakemodules"
-      GIT_REPOSITORY "https://github.com/jrl-umi3218/jrl-cmakemodules.git")
+      GIT_REPOSITORY "https://github.com/arntanguy/jrl-cmakemodules.git"
+      GIT_TAG 98c3f2676abcd84775863f27a8eabcd864115b49
+    )
     FetchContent_MakeAvailable("jrl-cmakemodules")
     FetchContent_GetProperties("jrl-cmakemodules" SOURCE_DIR JRL_CMAKE_MODULES)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,7 @@ else()
     FetchContent_Declare(
       "jrl-cmakemodules"
       GIT_REPOSITORY "https://github.com/arntanguy/jrl-cmakemodules.git"
-      GIT_TAG 98c3f2676abcd84775863f27a8eabcd864115b49
-    )
+      GIT_TAG 98c3f2676abcd84775863f27a8eabcd864115b49)
     FetchContent_MakeAvailable("jrl-cmakemodules")
     FetchContent_GetProperties("jrl-cmakemodules" SOURCE_DIR JRL_CMAKE_MODULES)
   endif()


### PR DESCRIPTION
Same patch as SpaceVecAlg
